### PR TITLE
Apply Erik's comments

### DIFF
--- a/draft-ietf-madinas-use-cases.txt
+++ b/draft-ietf-madinas-use-cases.txt
@@ -5,27 +5,30 @@
 Internet Engineering Task Force                                 J. Henry
 Internet-Draft                                             Cisco Systems
 Intended status: Informational                                    Y. Lee
-Expires: 25 December 2024                                        Comcast
-                                                            23 June 2024
+Expires: 15 May 2025                                             Comcast
+                                                        11 November 2024
 
 
-             Randomized and Changing MAC Address Use Cases
-                    draft-ietf-madinas-use-cases-10
+ Randomized and Changing MAC Address: Context, Network Impacts and Use
+                                 Cases
+                    draft-ietf-madinas-use-cases-11
 
 Abstract
 
    To limit the privacy issues created by the association between a
-   device, its traffic, its location and its user, client and client OS
-   vendors have started implementing MAC address rotation.  When such a
-   rotation happens, some in-network states may break, which may affect
-   network connectivity and user experience.  At the same time, devices
-   may continue using other stable identifiers, defeating the MAC
-   rotation purposes.  This document lists various network environments
-   and a set of network services that may be affected by such rotation.
-   This document then examines settings where the user experience may be
-   affected by in-network state disruption.  Last, this document
-   examines solutions to maintain user privacy while preserving user
-   quality of experience and network operation efficiency.
+   device, its traffic, its location and its user, client and client
+   Operation System vendors have started implementing MAC address
+   randomization.  When such a randomization happens, some in-network
+   states may break, which may affect network connectivity and user
+   experience.  At the same time, devices may continue using other
+   stable identifiers, defeating the MAC address randomization purposes.
+
+   This document lists various network environments and a set of network
+   services that may be affected by such randomization.  This document
+   then examines settings where the user experience may be affected by
+   in-network state disruption.  Last, this document examines solutions
+   to maintain user privacy while preserving user quality of experience
+   and network operation efficiency.
 
 Status of This Memo
 
@@ -42,21 +45,23 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 25 December 2024.
+   This Internet-Draft will expire on 15 May 2025.
+
+
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                  [Page 1]
+
+Internet-Draft                RCM Use Cases                November 2024
+
 
 Copyright Notice
 
    Copyright (c) 2024 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024                [Page 1]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
 
    This document is subject to BCP 78 and the IETF Trust's Legal
    Provisions Relating to IETF Documents (https://trustee.ietf.org/
@@ -70,23 +75,24 @@ Internet-Draft                RCM Use Cases                    June 2024
 Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
-   2.  MAC Address as Identity: User vs. Device  . . . . . . . . . .   3
+   2.  MAC Address as Identity: User vs. Device  . . . . . . . . . .   4
+     2.1.  Privacy of MAC Address  . . . . . . . . . . . . . . . . .   5
    3.  The Actors: Network Functional Entities and Human Entities  .   6
      3.1.  Network Functional Entities . . . . . . . . . . . . . . .   6
      3.2.  Human-related Entities  . . . . . . . . . . . . . . . . .   7
    4.  Trust Degrees . . . . . . . . . . . . . . . . . . . . . . . .   9
-   5.  Environments  . . . . . . . . . . . . . . . . . . . . . . . .   9
+   5.  Environments  . . . . . . . . . . . . . . . . . . . . . . . .  10
    6.  Network Services  . . . . . . . . . . . . . . . . . . . . . .  11
      6.1.  Device Identification and Associated Problems . . . . . .  11
-     6.2.  Use Cases . . . . . . . . . . . . . . . . . . . . . . . .  13
+     6.2.  Use Cases . . . . . . . . . . . . . . . . . . . . . . . .  14
    7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  15
    8.  Security Considerations . . . . . . . . . . . . . . . . . . .  15
    9.  Informative References  . . . . . . . . . . . . . . . . . . .  15
-   Appendix A.  Existing solutions . . . . . . . . . . . . . . . . .  16
-     A.1.  802.1X with WPA2 / WPA3 . . . . . . . . . . . . . . . . .  16
-     A.2.  OpenRoaming . . . . . . . . . . . . . . . . . . . . . . .  17
-     A.3.  Proprietary RCM schemes . . . . . . . . . . . . . . . . .  18
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  18
+   Appendix A.  Existing solutions . . . . . . . . . . . . . . . . .  17
+     A.1.  802.1X with WPA2 / WPA3 . . . . . . . . . . . . . . . . .  17
+     A.2.  OpenRoaming . . . . . . . . . . . . . . . . . . . . . . .  18
+     A.3.  Proprietary RCM schemes . . . . . . . . . . . . . . . . .  19
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  19
 
 1.  Introduction
 
@@ -95,28 +101,31 @@ Table of Contents
    technology used by devices such as laptops, tablets and Internet-of-
    Thing (IoT) devices.  Wi-Fi is an over-the-air technology, attackers
    with surveillance equipment can "monitor" WLAN packets and track the
-   activity of WLAN devices.  Once the association between a device and
-   its user is made, identifying the device and its activity is
-   sufficient to deduce information about what the user is doing,
-   without the user consent.
+   activity of WLAN devices.  It is also possible for attackers to
+   "monitor" the WLAN packers behind the Wi-Fi Access Point (AP) over
+   the wired Ethernet.  Once the association between a device and its
+   user is made, identifying the device and its activity is sufficient
+   to deduce information about what the user is doing, without the user
+
+
+
+Henry & Lee                Expires 15 May 2025                  [Page 2]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
+   consent.
 
    To reduce the risks of correlation between a device activity and its
-   owner's, multiple client and client OS vendors have started to
+   owner's, multiple clients, and client OS vendors have started to
    implement Randomized and Changing MAC addresses (RCM).  By
-   randomizing the MAC address, the persistent association between a
-   given traffic flow and a single device is made more difficult,
-   assuming no other visible unique identifiers or stable patterns are
-
-
-
-Henry & Lee             Expires 25 December 2024                [Page 2]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
-
-   in use.  When individual devices are no longer easily identifiable,
-   it also becomes difficult to associate a series of network flows with
-   a particular individual using one particular device.
+   randomizing the MAC address, it becomes harder to use the MAC address
+   to construct persistent association between a flow of data packets
+   and a device, assuming no other visible unique identifiers or stable
+   patterns are in use.  When individual devices are no longer easily
+   identifiable, it also becomes difficult to associate a series of
+   network flows with a particular individual using one particular
+   device.
 
    However, such address change may affect the user experience and the
    efficiency of legitimate network operations.  For a long time,
@@ -128,47 +137,52 @@ Internet-Draft                RCM Use Cases                    June 2024
    broken, network communication may be disrupted.  For example,
    sessions established between the end-device and network services may
    break and packets in transit may suddenly be lost.  If multiple
-   clients implement fast-paced RCM rotations without coordination with
-   network services, these network services may become over-solicited.
+   clients implement fast-paced MAC address randomization without
+   coordination with network services, these network services may become
+   over-solicited.
 
    At the same time, some network services rely on the end station (as
    defined by the [IEEE_802] Standard) providing an identifier, which
    can be the MAC address or another value.  If the client implements
-   MAC rotation but continues sending the same static identifier, then
-   the association between a stable identifier and the station continues
-   despite the RCM scheme.  There may be environments where such
-   continued association is desirable, but others where the user privacy
-   has more value than any continuity of network service state.
+   MAC address randomization but continues sending the same static
+   identifier, then the association between a stable identifier and the
+   station continues despite the RCM scheme.  There may be environments
+   where such continued association is desirable, but others where the
+   user privacy has more value than any continuity of network service
+   state.
 
-   There is a need to enumerate services that may be affected by RCM,
+   It could be useful to enumerate services that may be affected by RCM,
    and evaluate possible solutions to maintain both the quality of user
    experience and network efficiency while RCM happens and user privacy
    is reinforced.  This document presents such assessment and
    recommendations.
 
+   This document is organized as follows.
+
+
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                  [Page 3]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
 2.  MAC Address as Identity: User vs. Device
 
-   Any device member of a network implementing IEEE 802 technologies
-   includes several operating layers.  Among them, the Media Access
-   Control (MAC) layer defines rules to control how the device accesses
-   the shared medium.  In a network where a machine can communicate with
-   one or more other machines, one such rule is that each machine needs
-   to be identified, either as the target destination of a message, or
-   as the source of a message (and thus the target destination of the
-   answer).  Initially intended as a 48-bit (6 octets) value in the
-   first versions of the [IEEE_802] Standard, other Standards under the
-   [IEEE_802] umbrella then allowed this address to take an extended
-   format of 64 bits (8 octets), thus enabling a larger number of MAC
-   addresses to coexist as the 802 technologies became widely adopted.
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024                [Page 3]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
+   The Media Access Control (MAC) layer of IEEE 802 technologies defines
+   rules to control how a device accesses the shared medium.  In a
+   network where a machine can communicate with one or more other
+   machines, one such rule is that each machine needs to be identified,
+   either as the target destination of a message, or as the source of a
+   message (and thus the target destination of the answer).  Initially
+   intended as a 48-bit (6 octets) value in the first versions of the
+   [IEEE_802] Standard, other Standards under the [IEEE_802] umbrella
+   then allowed this address to take an extended format of 64 bits (8
+   octets), thus enabling a larger number of MAC addresses to coexist as
+   the 802 technologies became widely adopted.
 
    Regardless of the address length, different networks have different
    needs, and several bits of the first octet are reserved for specific
@@ -182,16 +196,14 @@ Internet-Draft                RCM Use Cases                    June 2024
    (clause 8.4 of [IEEE_802]).
 
    The intent of this provision is important for the present document.
-   The [IEEE_802] Standard recognized that some devices may never change
-   their attachment network and thus would not need a globally unique
-   MAC address to prevent address collision against any other device in
-   any other network.  To accommodate for this requirement, the second
-   bit of the MAC address first octet was designed to express whether
-   the address was intended to be globally unique, or locally unique.
-   The address allocation method was not defined in the Standard in this
-   later case, but the same clause defined that an address should be
-   unique so as to avoid collision with any other device attached to the
-   same network.
+   The [IEEE_802] Standard recognized that some devices (e.g., Smart
+   Thermostat) may never change their attachment network and thus would
+   not need a globally unique MAC address to prevent address collision
+   against any other device in any other network.  The Universally or
+   Locally Administered Address Bit is defined to signal the network
+   that the MAC Address is locally significant.  IEEE didn't define the
+   MAC Address allocation schema when L=1.  It states the address must
+   be unique in the same broadcast domain.
 
    It is also important to note that the purpose of the Universal
    version of the address was to avoid collisions and confusion, as any
@@ -201,10 +213,18 @@ Internet-Draft                RCM Use Cases                    June 2024
    operators that all potential members of a network need to have a
    unique identifier in that network (if they are going to coexist in
    the network without confusion on which machine is the source or
-   destination or any message).  The advantage of a universal address is
-   that a node with such an address can be attached to any Local Area
-   Network (LAN) in the world with an assurance that its address is
-   unique in that network.
+   destination or any message).  The advantage of a universally
+   administrated address is that a node with such an address can be
+   attached to any Local Area Network (LAN) in the world with an
+   assurance that its address is unique in that network.
+
+
+
+
+Henry & Lee                Expires 15 May 2025                  [Page 4]
+
+Internet-Draft                RCM Use Cases                November 2024
+
 
    With the rapid development of wireless technologies and mobile
    devices, this scenario became very common.  With a vast majority of
@@ -214,41 +234,39 @@ Internet-Draft                RCM Use Cases                    June 2024
    evolution brought the distinction between two types of devices that
    the [IEEE_802] Standard generally referred to as ‘nodes in a
    network’. Their definition is found in the [IEEE_802E] Recommended
-   Practice stated in Section 6.2 of [IEEE_802].  One type is a shared
-   service device, which functions are used by a number of people large
-   enough that the device itself, its functions or its traffic cannot be
-   associated with a single or small group of people.  Examples of such
+   Practice stated in Section 6.2 of [IEEE_802].
 
+   1.  Shared Service Device, which functions are used by a number of
+       people large enough that the device itself, its functions or its
+       traffic cannot be associated with a single or small group of
+       people.  Examples of such devices include switches in a dense
+       network, IEEE 802.11 (WLAN) access points in a crowded airport,
+       task-specific (e.g., barcode scanners) devices, etc.
 
+   2.  Personal Device, which is a machine, a node, primarily used by a
+       single person or small group of people, and so that any
+       identification of the device or its traffic can also be
+       associated to the identification of the primary user or their
+       traffic.
 
-Henry & Lee             Expires 25 December 2024                [Page 4]
-
-Internet-Draft                RCM Use Cases                    June 2024
+   The identification of the device is trivial if the device expresses a
+   universally unique MAC address.  Then, the detection of elements
+   directly or indirectly identifying the user of the device (Personally
+   Identifiable Information, or PII) is sufficient to tie the universal
+   MAC address to a user.  Then, any detection of traffic that can be
+   associated to the device becomes also associated with the known user
+   of that device (Personally Correlated Information, or PCI).
 
+2.1.  Privacy of MAC Address
 
-   devices include switches in a dense network, IEEE 802.11 (WLAN)
-   access points in a crowded airport, task-specific (e.g., barcode
-   scanners) devices, etc.  Another type is a personal device, which is
-   a machine, a node, primarily used by a single person or small group
-   of people, and so that any identification of the device or its
-   traffic can also be associated to the identification of the primary
-   user or their traffic.  Quite naturally, the identification of the
-   device is trivial if the device expresses a universally unique MAC
-   address.  Then, the detection of elements directly or indirectly
-   identifying the user of the device (Personally Identifiable
-   Information, or PII) is sufficient to tie the universal MAC address
-   to a user.  Then, any detection of traffic that can be associated to
-   the device becomes also associated with the known user of that device
-   (Personally Correlated Information, or PCI).
-
-   This possible identification or association presents a serious
-   privacy issue, especially with wireless technologies.  For most of
-   them, and in particular for 802.11, the source and destination MAC
-   addresses are not encrypted even in networks that implement
-   encryption (so that each machine can easily detect if it is the
-   intended target of the message before attempting to decrypt its
-   content, and also identify the transmitter, so as to use the right
-   decryption key when multiple unicast keys are in effect).
+   This possible identification or association presents a privacy issue,
+   especially with wireless technologies.  For most of them, and in
+   particular for 802.11, the source and destination MAC addresses are
+   not encrypted even in networks that implement encryption (so that
+   each machine can easily detect if it is the intended target of the
+   message before attempting to decrypt its content, and also identify
+   the transmitter, so as to use the right decryption key when multiple
+   unicast keys are in effect).
 
    This identification of the user associated to a node was clearly not
    the intent of the 802 MAC address.  A logical solution to remove this
@@ -256,6 +274,14 @@ Internet-Draft                RCM Use Cases                    June 2024
    change the address in a fashion that prevents a continuous
    association between one MAC address and some PII.  However, other
    network devices on the same LAN implementing a MAC layer also expect
+
+
+
+Henry & Lee                Expires 15 May 2025                  [Page 5]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
    each device to be associated to a MAC address that would persist over
    time.  When a device changes its MAC address, other devices on the
    same LAN may fail to recognize that the same machine is attempting to
@@ -265,22 +291,12 @@ Internet-Draft                RCM Use Cases                    June 2024
    would stay the same over time, and that this document calls a
    'persistent' MAC address.  This assumption sometimes adds to the PII
    confusion, for example in the case of Authentication, Association and
-   Accounting (AAA) services authenticating the user of a machine and
-   associating the authenticated user to the device MAC address.  Other
-   services solely focus on the machine (e.g., DHCP), but still expect
-   each device to use a persistent MAC address, for example to re-assign
-   the same IP address to a returning device.  Changing the MAC address
-   may disrupt these services.
-
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024                [Page 5]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
+   Accounting (AAA) services [RFC3539] authenticating the user of a
+   machine and associating the authenticated user to the device MAC
+   address.  Other services solely focus on the machine (e.g., DHCPv4
+   [RFC2131]), but still expect each device to use a persistent MAC
+   address, for example to re-assign the same IP address to a returning
+   device.  Changing the MAC address may disrupt these services.
 
 3.  The Actors: Network Functional Entities and Human Entities
 
@@ -296,7 +312,7 @@ Internet-Draft                RCM Use Cases                    June 2024
 
    Network communications based on IEEE 802 technologies commonly rely
    on station identifiers based on a MAC address.  This MAC address is
-   utilized by several types of network functional entitities (entities,
+   utilized by several types of network functional entities (entities,
    like applications or devices, that provide a service related to
    network operations).
 
@@ -311,144 +327,135 @@ Internet-Draft                RCM Use Cases                    June 2024
    contextual information (e.g., device MAC, keying material) allowing
    the device session to continue seamlessly.  These access points can
    also inform devices further in the wired network about the roam, to
-   ensure that OSI model Layer 2 frames are redirected to the new device
-   access point.
-
-   Other network devices operating at the MAC layer: many wireless
-   network access devices (e.g., IEEE 802.11 access points) are
-   conceived as Layer 2 devices, and as such they bridge a frame from
-   one medium (e.g., IEEE 802.11 or Wi-Fi) to another (e.g., IEEE 802.3
-   or Ethernet).  This means that a wireless device MAC address often
-   exists on the wire beyond the wireless access device.  Devices
-   connected to this wire also implement IEEE 802 technologies, and as
-   such operate on the expectation that each device is associated to a
-   MAC address that persists for the duration of continuous exchanges.
-   For example, switches and bridges associate MAC addresses to
-   individual ports (so as to know which port to send a frame intended
-   for a particular MAC address).  Similarly, authentication,
-   authorization and accounting (AAA) services can validate the identity
-   of a device and use the device MAC address as a first pointer to the
-   device identity (before operating further verification).  Similarly,
-   some networking devices offer Layer-2 filtering policies that may
+   ensure that layer-2 frames are redirected to the new device access
+   point.
 
 
 
-Henry & Lee             Expires 25 December 2024                [Page 6]
+
+Henry & Lee                Expires 15 May 2025                  [Page 6]
 
-Internet-Draft                RCM Use Cases                    June 2024
+Internet-Draft                RCM Use Cases                November 2024
 
 
-   rely on the connected MAC addresses. 802.1X-enabled devices may also
-   selectively block the data portion of a port until a connecting
-   device is authenticated.  These services then use the MAC address as
-   a first pointer to the device identity to allow or block data
-   traffic.  This list is not exhaustive.  Multiple services are defined
-   for 802.3 networks, and multiple services defined by the IEEE 802.1
-   working group are also applicable to 802.3 networks.  Wireless access
-   points may also connect to other mediums than 802.3, which also
-   implements mechanism under the umbrella of the general 802 Standard,
-   and therefore expect the unique and persistent association of a MAC
-   address to a device.
+   1.  Wireless Access Point: Many wireless network access devices
+       (e.g., IEEE 802.11 access points) are conceived as layer-2
+       devices, and as such they bridge a frame from one medium (e.g.,
+       IEEE 802.11 or Wi-Fi) to another (e.g., IEEE 802.3 or Ethernet).
+       This means that a wireless device MAC address often exists on the
+       wire beyond the wireless access device.  Devices connected to
+       this wire also implement IEEE 802.3 technologies, and as such
+       operate on the expectation that each device is associated to a
+       MAC address that persists for the duration of continuous
+       exchanges.  For example, switches and bridges associate MAC
+       addresses to individual ports (so as to know which port to send a
+       frame intended for a particular MAC address).  Similarly, AAA
+       services can validate the identity of a device and use the device
+       MAC address as a first pointer to the device identity (before
+       operating further verification).  Similarly, some networking
+       devices offer layer-2 filtering policies that may rely on the
+       connected MAC addresses. 802.1X-enabled [IEEE_802.1X] devices may
+       also selectively put the interface in blocking state until a
+       connecting device is authenticated.  These services then use the
+       MAC address as a first pointer to the device identity to allow or
+       block data traffic.  This list is not exhaustive.  Multiple
+       services are defined for 802.3 networks, and multiple services
+       defined by the IEEE 802.1 working group are also applicable to
+       802.3 networks.  Wireless access points may also connect to other
+       mediums than 802.3, which also implements mechanism under the
+       umbrella of the general 802 Standard, and therefore expect the
+       unique and persistent association of a MAC address to a device.
 
-   Network devices operating at upper layers: some network devices
-   provide functions and services above the MAC layer.  Some of them
-   also operate a MAC layer function: for example, routers provide IP
-   forwarding services, but rely on the device MAC address to create the
-   appropriate frame structure.  Other devices and services operate at
-   upper layers, but also rely upon the 802 principle of unique MAC-to-
-   device mapping.  For example, DHCP services with IPv4 commonly
-   provide a single IP address per MAC address (they do not assign more
-   than one IP address per MAC address, and assign a new IP address to
-   each new requesting MAC address).  ARP and reverse-ARP services
-   commonly expect that, once an IP-to-MAC mapping has been established,
-   this mapping is valid and unlikely to change for the cache lifetime.
-   DHCP services with IPv6 commonly do not assign the same IP address to
-   two different requesting MAC addresses.  Hybrid services, such as
-   EoIP, also assume stability of the device-to-MAC-and-IP mapping for
-   the duration of a given session.
+   2.  Address Resolution Protocol and Neighbor Discovery Protocol:
+       Address Resolution Protocol (ARP) [RFC826] and Neighbor Discovery
+       Protocol (NDP) [RFC4861] use MAC address to create the mapping of
+       an IP address to a MAC address for packet forwarding.  If a
+       device changed a MAC address without notifying the layer-2 switch
+       it is connected to, network connectivity would be interrupted
+       until the layer-2 switch learned the new MAC address and updated
+       the table.
 
 3.2.  Human-related Entities
 
-   Networks do no operate without humans actively involved at one or
-   more points of the network lifecycle.  Humans may actively
-   participate to the network structure and operations, or be observers.
+   Humans may actively participate to the network structure and
+   operations, or be observers at any point of network lifecycle.
+   Humans could be wireless device users or people operating the
+   wireless networks.
 
-   Over the air (OTA) observers: as the transmitting or receiving MAC
-   address is usually not encrypted in wireless 802-technologies
-   exchanges, and as any protocol-compatible device in range of the
-   signal can read the frame header, OTA observers are able to read
-   individual transmissions MAC addresses.  Some wireless technologies
-   also support techniques to establish distances or positions, allowing
-   the observer, in some cases, to uniquely associate the MAC address to
-   a physical device and it associated location.  It can happen that an
-   OTA observer has a legitimate reason to monitor a particular device,
-   for example for IT support operations.  However, it is difficult to
-   control if another actor also monitors the same station with the goal
-   of obtaining PII or PCI.
+   1.  Over the air (OTA) observers: As the transmitting or receiving
+       MAC address is usually not encrypted in wireless 802-technologies
+       exchanges, and as any protocol-compatible device in range of the
+       signal can read the frame header, OTA observers are able to read
 
 
 
-
-Henry & Lee             Expires 25 December 2024                [Page 7]
+Henry & Lee                Expires 15 May 2025                  [Page 7]
 
-Internet-Draft                RCM Use Cases                    June 2024
+Internet-Draft                RCM Use Cases                November 2024
 
 
-   Wireless access network operators: some wireless access networks are
-   only provided devices matching specific requirements, such as device
-   type (e.g., IoT-only networks, factory operational networks).
-   Therefore, operators can attempt to identify the devices (or the
-   users) connecting to the networks under their care.  They can use the
-   MAC address to represent an identified device.
+       individual transmissions MAC addresses.  Some wireless
+       technologies also support techniques to establish distances or
+       positions, allowing the observer, in some cases, to uniquely
+       associate the MAC address to a physical device and it associated
+       location.  It can happen that an OTA observer has a legitimate
+       reason to monitor a particular device, for example for IT support
+       operations.  However, it is difficult to control if another actor
+       also monitors the same station with the goal of obtaining PII or
+       PCI.
 
-   Network access providers: wireless access networks are often
-   considered beyond the first 2 layers of the OSI model.  For example,
-   several regulatory or legislative bodies can group all OSI layers
-   into their functional effect of allowing network communication
-   between machines.  In this context, entities operating access
-   networks can see their liability associated to the activity of
-   devices communicating through the networks that these entities
-   operate.  In other contexts, operators assign network resources based
-   on contractual conditions (e.g., fee, bandwidth fair share).  In
-   these scenarios, these operators may attempt to identify the devices
-   and the users of their networks.  They can use the MAC address to
-   represent an identified device.
+   2.  Wireless access network operators: some wireless access networks
+       are only provided devices matching specific requirements, such as
+       device type (e.g., IoT-only networks, factory operational
+       networks).  Therefore, operators can attempt to identify the
+       devices (or the users) connecting to the networks under their
+       care.  They can use the MAC address to represent an identified
+       device.
 
-   Over the wire internal (OTWi) observers: because the device wireless
-   MAC address continues to be present over the wire if the
-   infrastructure connection device (e.g., access point) functions as a
-   Layer 2 bridge, observers may be positioned over the wire and read
-   transmission MAC addresses.  Such capability supposes that the
-   observer has access to the wired segment of the broadcast domain
-   where the frames are exchanged.  In most networks, such capability
-   requires physical access to an infrastructure wired device in the
-   broadcast domain (e.g., switch closet), and is therefore not
-   accessible to all.
+   3.  Network access providers: wireless access networks are often
+       considered beyond the first 2 layers of the OSI model.  For
+       example, several regulatory or legislative bodies can group all
+       OSI layers into their functional effect of allowing network
+       communication between machines.  In this context, entities
+       operating access networks can see their liability associated to
+       the activity of devices communicating through the networks that
+       these entities operate.  In other contexts, operators assign
+       network resources based on contractual conditions (e.g., fee,
+       bandwidth fair share).  In these scenarios, these operators may
+       attempt to identify the devices and the users of their networks.
+       They can use the MAC address to represent an identified device.
 
-   Over the wired external (OTWe) observers: beyond the broadcast
-   domain, frames headers are removed by a routing device, and a new
-   Layer 2 header is added before the frame is transmitted to the next
-   segment.  The personal device MAC address is not visible anymore,
-   unless a mechanism copies the MAC address into a field that can be
-   read while the packet travels onto the next segment (e.g., pre-
-   [RFC4941] and pre- [RFC7217] IPv6 addresses built from the MAC
-   address).  Therefore, unless this last condition exists, OTWe
-   observers are not able to see the device MAC address.
+   4.  Over the wire internal (OTWi) observers: because the device
+       wireless MAC address continues to be present over the wire if the
+       infrastructure connection device (e.g., access point) functions
+       as a layer-2 bridge, observers may be positioned over the wire
+       and read transmission MAC addresses.  Such capability supposes
+       that the observer has access to the wired segment of the
+       broadcast domain where the frames are exchanged.  A Broadcast
+       Domain is a logical division of a network where a device in the
+       division can send, receive and monitor data frames from all
+       devices in the same division.  In most networks, such capability
+       requires physical access to an infrastructure wired device in the
+       broadcast domain (e.g., switch closet), and is therefore not
+       accessible to all.
 
-
-
-
-
-
-
+   5.  Over the wired external (OTWe) observers: beyond the broadcast
+       domain, frames headers are removed by a routing device, and a new
+       layer-2 header is added before the frame is transmitted to the
 
 
 
-
-Henry & Lee             Expires 25 December 2024                [Page 8]
+Henry & Lee                Expires 15 May 2025                  [Page 8]
 
-Internet-Draft                RCM Use Cases                    June 2024
+Internet-Draft                RCM Use Cases                November 2024
 
+
+       next segment.  The personal device MAC address is not visible
+       anymore, unless a mechanism copies the MAC address into a field
+       that can be read while the packet travels onto the next segment
+       (e.g., pre- [RFC4941] and pre-[RFC7217] IPv6 addresses built from
+       the MAC address).  Therefore, unless this last condition exists,
+       OTWe observers are not able to see the device MAC address.
 
 4.  Trust Degrees
 
@@ -468,15 +475,15 @@ Internet-Draft                RCM Use Cases                    June 2024
        establishes a trust relationship and can share a persistent
        device identity with the access network devices (e.g., access
        point and WLAN Controller), the services beyond the access point
-       in the L2 broadcast domain (e.g., DHCP, AAA), without fear that
-       observers or network actors may access PII that would not be
+       in the layer-2 broadcast domain (e.g., DHCP, AAA), without fear
+       that observers or network actors may access PII that would not be
        shared willingly.  The personal device (or its user) also has
-       confidence that its identity is not shared beyond the L2
+       confidence that its identity is not shared beyond the layer-2
        broadcast domain boundary.
 
    2.  Selective trust: in other environments, a device may not be
        willing to share a persistent identity with some elements of the
-       Layer 2 broadcast domain, but may be willing to share a
+       layer-2 broadcast domain, but may be willing to share a
        persistent identity with other elements.  That persistent
        identity may or may not be the same for different services.
 
@@ -485,6 +492,19 @@ Internet-Draft                RCM Use Cases                    June 2024
        through the AP, and may express a temporal identity to each of
        them.  That temporal identity may or not be the same for
        different services.
+
+
+
+
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                  [Page 9]
+
+Internet-Draft                RCM Use Cases                November 2024
+
 
 5.  Environments
 
@@ -496,26 +516,18 @@ Internet-Draft                RCM Use Cases                    June 2024
    A.  Residential settings under the control of the user: this is
        typical of a home network with Wi-Fi in the LAN and Internet
        connection.  In this environment, traffic over the Internet does
-       not expose the MAC adddress of internal devices if it is not
-       copied to another field before routing happens.  The wire segment
-
-
-
-Henry & Lee             Expires 25 December 2024                [Page 9]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
-
-       within the broadcast domain is under the control of the user, and
-       is therefore usually not at risk of hosting an eavesdropper.
-       Full trust is typically established at this level among users and
-       with the network elements.  The device trusts the access point
-       and all L2 domain entities beyond the access point.  However,
-       unless the user has full access control over the physical space
-       where the Wi-Fi transmissions can be detected, there is no
-       guarantee that an eavesdropper would not be observing the
-       communications.  As such, it is common to assume that, even in
-       this environment, full trust cannot be achieved.
+       not expose the MAC address of internal device if it is not copied
+       to another field before routing happens.  The wire segment within
+       the broadcast domain is under the control of the user, and is
+       therefore usually not at risk of hosting an eavesdropper.  Full
+       trust is typically established at this level among users and with
+       the network elements.  The device trusts the access point and all
+       layer-2 domain entities beyond the access point.  However, unless
+       the user has full access control over the physical space where
+       the Wi-Fi transmissions can be detected, there is no guarantee
+       that an eavesdropper would not be observing the communications.
+       As such, it is common to assume that, even in this environment,
+       full trust cannot be achieved.
 
    B.  Managed residential settings: examples of this type of
        environment include shared living facilities and other collective
@@ -533,19 +545,30 @@ Internet-Draft                RCM Use Cases                    June 2024
        is a common condition for the managed operations.
 
    C.  Public guest networks: public hotspots, such as in shopping
-       malls, hotels, stores, trains stations and airports are typical
+       malls, hotels, stores, train-stations, and airports are typical
        of this environment.  The guest network operator may be legally
        mandated to identify devices or users or may have the option to
        leave all devices and users untracked.  In this environment,
-       trust is commonly not established with any element of the L2
+       trust is commonly not established with any element of the layer-2
        broadcast domain (Zero trust model by default).
 
-   D.  Enterprises (with BYOD): users may be provided with corporate
-       devices or may bring their own devices.  The devices are not
-       directly under the control of a corporate IT team.  Trust may be
-       established as the device joins the network.  Some enterprise
-       models will mandate full trust, others, considering the BYOD
-       nature of the device, will allow selective trust.
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 10]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
+   D.  Enterprises with Bring-Your-Own-Device (BYOD): users may be
+       provided with corporate devices or may bring their own devices.
+       The devices are not directly under the control of a corporate IT
+       team.  Trust may be established as the device joins the network.
+       Some enterprise models will mandate full trust, others,
+       considering the BYOD nature of the device, will allow selective
+       trust.
 
    E.  Managed enterprises: in this environment, users are typically
        provided with corporate devices, and all connected devices are
@@ -553,135 +576,134 @@ Internet-Draft                RCM Use Cases                    June 2024
        profile installed on the device.  Full trust is created as the
        MDM profile is installed.
 
-
-
-
-
-Henry & Lee             Expires 25 December 2024               [Page 10]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
-
 6.  Network Services
 
    Different network environments provide different levels of network
    services, from simple to complex.  At its simplest level, a network
    can provide to a wireless connecting device basic address allocation
-   service (DHCP) and an ability to connect to the Internet (e.g., DNS
-   service or relay, and routing in and out through a local gateway).
-   The network can also offer more advanced services, such as file
-   storage, printing or local web service.  Larger and more complex
-   networks can also incorporate a multiplicity of more advanced
-   services, from authentication (AAA), to quality of experience (QoE)
-   monitoring and management.  These services are often accompanied with
-   network performance management services.  Different levels of
-   services may call for different relationships with the device, or its
-   user, identity.  For example, there is usually no need to identify
-   the device or its user for a public network to provide a DHCP-sourced
-   IP address to a connecting station, or accept a station using its
-   self-generated IP address (e.g., using SLAAC [RFC4862] ).  However,
-   there may be a need, in an enterprise private network, to identify
-   devices in order to provide adapted quality of services (e.g., to
-   prioritize identified voice traffic coming from a smartphone over
-   keepalive data coming from an IoT endpoint).  The same type of
-   network may have a need to limit the effect of IP address spoofing
-   and invalid reuse through mechanisms like SAVI [RFC6620] .
+   service (e.g., DHCPv4 [RFC2131] or SLAAC [RFC4862]) and an ability to
+   connect to the Internet (e.g., DNS service or relay, and routing in
+   and out through a local gateway).  The network can also offer more
+   advanced services, such as file storage, printing or local web
+   service.  Larger and more complex networks can also incorporate a
+   multiplicity of more advanced services, from AAA, to Quality of
+   Experience monitoring and management.  These services are often
+   accompanied with network performance management services.  Different
+   levels of services may call for different relationships with the
+   device, its user and the identity.  For example, there is usually no
+   need to identify the device or its user in a public network.
+   However, there may be a need, in an enterprise private network, to
+   associate a device to an identity in order to provide adapted quality
+   of services (e.g., to prioritize identified voice traffic coming from
+   a smartphone over keepalive data coming from an IoT endpoint).  The
+   same type of network may have a need to limit the effect of IP
+   address spoofing and invalid reuse through mechanisms like SAVI
+   [RFC6620].
 
 6.1.  Device Identification and Associated Problems
 
-   Many network functional devices offering a service to a personal
-   device use the device MAC address to maintain service continuity.
-
    Wireless access points and controllers use the MAC address to
    validate the device connection context, including protocol
-   capabilities, confirmation that authentication was completed, QoS or
-   security profiles, encryption key material.  Some advanced access
-   points and controllers also include upper layer functions which
-   purpose is covered below.  A device changing its MAC address, without
-   another recorded device identity, would cause the access point and
-   the controller to lose these parameters.  As such, the Layer 2
-   infrastructure does not know that the device (with its new MAC
-   address) is authorized to communicate through the network.  The
-   encryption keying material is not identified anymore (causing the
+   capabilities, confirmation that authentication was completed, Quality
+   of Service or security profiles, encryption key material.  Some
+   advanced access points and controllers also include upper layer
+   functions which purpose is covered below.  A device changing its MAC
+   address, without another recorded device identity, would cause the
+   access point and the controller to lose these parameters.  As such,
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 11]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
+   the layer-2 infrastructure does not know that the device (with its
+   new MAC address) is authorized to communicate through the network.
+   The encryption keying material is not identified anymore (causing the
    access point to fail decrypting the device traffic, and fail
    selecting the right key to send encrypted traffic to the device).  In
    short, the entire context needs to be rebuilt, and a new session
    restarted.  The time consumed by this procedure breaks any flow that
    needs continuity or short delay between packets on the device (e.g.,
-   real-time audio, video, AR/VR, etc.)  The 802.11i Standard recognizes
-   that a device may leave the network and come back after a short time
+   real-time audio, video, AR/VR, etc.)  The 802.11i Standard
+   [IEEE_802.11i] recognizes that a device may leave the network and
+   come back after a short time window.  As such, the standard suggests
+   that the infrastructure should keep the context for a device for a
+   while after the device was last seen.  MAC address randomization in
+   this context can cause resource exhaustion on the wireless
+   infrastructure and the flush of contexts, including for devices that
+   are simply in temporal sleep mode.
+
+   Layer-2 switches rely on ARP [RFC826] and NDP [RFC4861], and use the
+   MAC address to forward frames.  Aggressive MAC randamization from
+   many devices in a short time-interval may cause the layer-2 switch to
+   exhaust its resources, holding in memory traffic for a device which
+   port location can no longer be found.  As these infrastructure
+   devices also implement a cache (to remember the port position of each
+   known device), too frequent MAC address randomization can cause
+   resources exhaustion and the flush of older MAC addresses, including
+   for devices that did not rotate their MAC.  For the RCM device, these
+   effects translate into session discontinuity and return traffic
+   losses.
+
+   In wireless contexts, 802.1X [IEEE_802.1X] authenticators rely on the
+   device and user identity validation provided by a AAA server to
+   change the interface from blocking state to forwarding state.  The
+   MAC address is used to verify that the device is in the authorized
+   list, and the associated key used to decrypt the device traffic.  A
+   change in MAC address causes the port to be closed to the device data
+   traffic until the AAA server confirms the validity of the new MAC
+   address.  Therefore, MAC address randomization can interrupt the
+   device traffic, and cause a strain on the AAA server.
 
 
 
-Henry & Lee             Expires 25 December 2024               [Page 11]
+
+
+
+
+
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 12]
 
-Internet-Draft                RCM Use Cases                    June 2024
+Internet-Draft                RCM Use Cases                November 2024
 
 
-   window.  As such, the standard suggests that the infrastructure
-   should keep the context for a device for a while after the device was
-   last seen.  MAC address rotation in this context can cause resource
-   exhaustion on the wireless infrastructure and the flush of contexts,
-   including for devices that are simply in temporal sleep mode.
-
-   Other devices in the Layer 2 broadcast domain also use the MAC
-   address to know whether and where to forward frames.  MAC rotation
-   can cause these devices to exhaust their resources, holding in memory
-   traffic for a device which port location can no longer be found.  As
-   these infrastructure devices also implement a cache (to remember the
-   port position of each known device), too frequent MAC rotation can
-   cause resources exhaustion and the flush of older MAC addresses,
-   including for devices that did not rotate their MAC.  For the RCM
-   device, these effects translate into session discontinuity and return
-   traffic losses.
-
-   In wireless contexts, 802.1X authenticators rely on the device and
-   user identity validation provided by a AAA server to open their port
-   to data transmission.  The MAC address is used to verify that the
-   device is in the authorized list, and the associated key used to
-   decrypt the device traffic.  A change in MAC address causes the port
-   to be closed to the device data traffic until the AAA server confirms
-   the validity of the new MAC address.  Therefore, MAC rotation can
-   interrupt the device traffic, and cause a strain on the AAA server.
-
-   DHCP servers, without a unique identification of the device, lose
+   DHCPv4 servers, without a unique identification of the device, lose
    track of which IP address is validly assigned.  Unless the RCM device
-   releases the IP address before the rotation occurs, DHCP servers are
-   at risk of scope exhaustion, causing new devices (and RCM devices) to
-   fail to obtain a new IP address.  Even if the RCM device releases the
-   IP address before the rotation occurs, the DHCP server typically
-   holds the released IP address for a certain duration, in case the
-   leaving MAC would return.  As the DHCP server cannot know if the
-   release is due to a temporal disconnection or a MAC rotation, the
-   risk of scope address exhaustion exists even in cases where the IP
-   address is released.
+   releases the IP address before changing the MAC address.  DHCPv4
+   servers are at risk of scope exhaustion, causing new devices (and RCM
+   devices) to fail to obtain a new IP address.  Even if the RCM device
+   releases the IP address before changing the MAC address, the DHCPv4
+   server typically holds the released IP address for a certain
+   duration, in case the leaving MAC would return.  As the DHCPv4 server
+   cannot know if the release is due to a temporal disconnection or a
+   MAC randomization, the risk of scope address exhaustion exists even
+   in cases where the IP address is released.
 
-   Network devices using self-assigned IPv6 addresses (e.g., with SLAAC
-   defined in [RFC6620] ) use mechanisms like DAD to and ND to establish
-   the association between a target IP address and a MAC address, and
-   may cache this association in memory.  Changing the MAC address, even
+   Network devices with self-assigned IPv6 addresses (e.g., with SLAAC
+   defined in [RFC6620]) use mechanisms like Optimistic Duplicate
+   Address Detection (DAD) [RFC4429] and NDP [RFC4861] to establish the
+   association between a target IP address and a MAC address, and may
+   cache this association in memory.  Changing the MAC address, even
    through a disconnection-reconnection phase, without changing the IP
    address, may disrupt the stability of these mappings, if the change
-   occurs within the caching period.
-
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024               [Page 12]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
+   occurs within the caching period.  Similarly, static IP assignment
+   will break if the MAC address changes without updating the mapping.
 
    Routers keep track of which MAC address is on which interface.  MAC
-   rotation can cause MAC address cache exhaustion, but also the need
-   for frequent ARP and inverse ARP exchanges.
+   address randomization can cause MAC address cache exhaustion, but
+   also the need for frequent ARP and inverse ARP exchanges.
 
    In residential settings (environments type A in section Section 5),
    policies can be in place to control the traffic of some devices
    (e.g., parental control or block-list filters).  These policies are
-   often based on the device MAC address.  Rotation of the MAC address
+   often based on the device MAC address.  MAC address randomization
    removes the possibility for such control.
 
    In residential settings (environments type A) and in enterprises
@@ -689,66 +711,58 @@ Internet-Draft                RCM Use Cases                    June 2024
    used for IoT-related functionalities (door unlock, preferred light
    and temperature configuration, etc.)  These functions often rely on
    the detection of the device wireless MAC address.  MAC address
-   rotation breaks the services based on such model.
+   randomization breaks the services based on such model.
 
    In managed residential settings (environments types B) and in
    enterprises (environments types D and E), the network operator is
-   often requested to provide IT support.  With MAC address rotation,
-   real time support is only possible if the user is able to provide the
-   current MAC address.  Service improvement support is not possible if
-   the MAC address that the device had at the (past) time of the
-   reported issue is not known at the time the issue is reported.
+   often requested to provide IT support.  With MAC address
+   randomization, real time support is only possible if the user is able
+   to provide the current MAC address.  Service improvement support is
+   not possible if the MAC address that the device had at the (past)
+   time of the reported issue is not known at the time the issue is
+   reported.
+
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 13]
+
+Internet-Draft                RCM Use Cases                November 2024
+
 
    In industrial environments, policies are associated to each group of
-   objects, including IoT.  MAC address rotation may prevent an IoT
+   objects, including IoT.  MAC address randomization may prevent an IoT
    device from being identified properly, thus leading to network
    quarantine and disruption of operations.
 
 6.2.  Use Cases
 
    Section 6.1 discusses different environments, different settings, and
-   the expectations of users and network operators.  Table 1 summarizes
+   the expectations of users and network operators.Table 1 summarizes
    the expected degree of trust, network admin responsibility,
    complexity of supported network services and network support
    expectation from the user for the different use cases.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024               [Page 13]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
-
-   +=============+==============+=========+==========+=================+
-   |  Use Cases  |    Trust     | Network | Network  | Network Support |
-   |             |    Degree    |  Admin  | Services |   Expectation   |
-   +=============+==============+=========+==========+=================+
-   |     Home    |    Medium    |   User  |  Medium  |       Low       |
-   +-------------+--------------+---------+----------+-----------------+
-   |   Managed   |    Medium    |    IT   |  Medium  |      Medium     |
-   | Residential |              |         |          |                 |
-   +-------------+--------------+---------+----------+-----------------+
-   |    Campus   |    Medium    |    IT   | Complex  |      Medium     |
-   |    (BYOD)   |              |         |          |                 |
-   +-------------+--------------+---------+----------+-----------------+
-   |  Enterprise |     High     |    IT   | Complex  |       High      |
-   |    (MDM)    |              |         |          |                 |
-   +-------------+--------------+---------+----------+-----------------+
-   | Hospitality |     Low      |    IT   |  Simple  |      Medium     |
-   +-------------+--------------+---------+----------+-----------------+
-   | Public WiFi |     Low      |   ISP   |  Simple  |       Low       |
-   +-------------+--------------+---------+----------+-----------------+
+    +=======================+======+=========+==========+=============+
+    |       Use Cases       |Trust | Network | Network  |   Network   |
+    |                       |Degree|  Admin  | Services |   Support   |
+    |                       |      |         |          | Expectation |
+    +=======================+======+=========+==========+=============+
+    |  Residential settings |Medium|   User  |  Medium  |     Low     |
+    |  under the control of |      |         |          |             |
+    |        the user       |      |         |          |             |
+    +-----------------------+------+---------+----------+-------------+
+    |  Managed residential  |Medium|    IT   |  Medium  |    Medium   |
+    |        settings       |      |         |          |             |
+    +-----------------------+------+---------+----------+-------------+
+    | Public guest networks | Low  |   ISP   |  Simple  |     Low     |
+    +-----------------------+------+---------+----------+-------------+
+    |    Enterprises with   |Medium|    IT   | Complex  |    Medium   |
+    | Bring-Your-Own-Device |      |         |          |             |
+    |         (BYOD)        |      |         |          |             |
+    +-----------------------+------+---------+----------+-------------+
+    |  Managed enterprises  | High |    IT   | Complex  |     High    |
+    +-----------------------+------+---------+----------+-------------+
 
                              Table 1: Use Cases
 
@@ -764,27 +778,25 @@ Internet-Draft                RCM Use Cases                    June 2024
    Parental Control).  Most home users do not expect to need networking
    skills to manage their home network.  Such environments may lead to
    full-trust conditions.  However, if the trust commonly exists between
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 14]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
    allowed actors, there is no guarantee that an eavesdropper would not
    be observing the Wi-Fi traffic from outside, thus practically
    limiting the applicability of the trust in most home scenarios.
 
    On the other end of the spectrum, Public Wi-Fi is often considered to
    be completely untrusted, where a user has no expectation of being
-   able to trust other users or any actor inside or outside of the Layer
-   2 domain.  Privacy is the number one concern for the user.  Most
-   users connecting to Public Wi-Fi only require simple Internet
+   able to trust other users or any actor inside or outside of the
+   layer-2 domain.  Privacy is the number one concern for the user.
+   Most users connecting to Public Wi-Fi only require simple Internet
    connectivity service, and expect only limited to no technical
    support.
-
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024               [Page 14]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
 
    There are existing technical solutions that address some of the
    requirements from several of the use cases listed above.  Appendix A
@@ -804,43 +816,97 @@ Internet-Draft                RCM Use Cases                    June 2024
               Tomas, B., "WBA OpenRoaming Wireless Federation", IETF ,
               2024.
 
+   [I-D.ietf-radext-deprecating-radius]
+              DeKok, A., "Deprecating Insecure Practices in RADIUS",
+              Work in Progress, Internet-Draft, draft-ietf-radext-
+              deprecating-radius-04, 11 November 2024,
+              <https://datatracker.ietf.org/api/v1/doc/document/draft-
+              ietf-radext-deprecating-radius/>.
+
    [IEEE_802] IEEE 802, "IEEE Std 802 - IEEE Standard for Local and
               Metropolitan Area Networks: Overview and Architecture",
               IEEE 802 , 2014.
 
    [IEEE_802.11]
-              IEEE 802.11 WG - 802 LAN/MAN Standards Committee, "IEEE
-              802.11-2020 - Wireless LAN Medium Access Control (MAC) and
-              Physical Layer (PHY) Specifications", IEEE 802.11 , 2020.
+              "IEEE 802.11-2020 - Wireless LAN Medium Access Control
+              (MAC) and Physical Layer (PHY) Specifications", IEEE
+              802.11 , 2020.
+
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 15]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
+   [IEEE_802.11bh]
+              "IEEE 802.11bh-2024 - Wireless LAN Medium Access Control
+              (MAC) and Physical Layer (PHY) Specifications Amendment 1:
+              Operation with Randomized and Changing MAC Addresses",
+              IEEE 802.11bh , 2024.
+
+   [IEEE_802.11i]
+              "IEEE 802.11i-2004 - Wireless LAN Medium Access Control
+              (MAC) and Physical Layer (PHY) specifications: Amendment
+              6: Medium Access Control (MAC) Security Enhancements",
+              IEEE 802.11i , 2004.
+
+   [IEEE_802.1X]
+              "IEEE 802.1X-2020 - IEEE Standard for Local and
+              Metropolitan Area Networks--Port-Based Network Access
+              Control", IEEE 802.1X , 2020.
 
    [IEEE_802E]
-              IEEE 802.1 WG - 802 LAN/MAN architecture, "IEEE 802E-2020
-              - IEEE Recommended Practice for Privacy Considerations for
-              IEEE 802 Technologies", IEEE 802E , 2020.
+              "IEEE 802E-2020 - IEEE Recommended Practice for Privacy
+              Considerations for IEEE 802 Technologies", IEEE 802E ,
+              2020.
+
+   [RFC2131]  Droms, R., "Dynamic Host Configuration Protocol",
+              RFC 2131, DOI 10.17487/RFC2131, March 1997,
+              <https://www.rfc-editor.org/info/rfc2131>.
+
+   [RFC3539]  Aboba, B. and J. Wood, "Authentication, Authorization and
+              Accounting (AAA) Transport Profile", RFC 3539,
+              DOI 10.17487/RFC3539, June 2003,
+              <https://www.rfc-editor.org/info/rfc3539>.
+
+   [RFC4429]  Moore, N., "Optimistic Duplicate Address Detection (DAD)
+              for IPv6", RFC 4429, DOI 10.17487/RFC4429, April 2006,
+              <https://www.rfc-editor.org/info/rfc4429>.
+
+   [RFC4861]  Narten, T., Nordmark, E., Simpson, W., and H. Soliman,
+              "Neighbor Discovery for IP version 6 (IPv6)", RFC 4861,
+              DOI 10.17487/RFC4861, September 2007,
+              <https://www.rfc-editor.org/info/rfc4861>.
 
    [RFC4862]  Thomson, S., Narten, T., and T. Jinmei, "IPv6 Stateless
               Address Autoconfiguration", RFC 4862,
               DOI 10.17487/RFC4862, September 2007,
               <https://www.rfc-editor.org/info/rfc4862>.
 
+
+
+
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 16]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
    [RFC4941]  Narten, T., Draves, R., and S. Krishnan, "Privacy
               Extensions for Stateless Address Autoconfiguration in
               IPv6", RFC 4941, DOI 10.17487/RFC4941, September 2007,
               <https://www.rfc-editor.org/info/rfc4941>.
 
-   [RFC5176]  Chiba, M., Dommety, G., Eklund, M., Mitton, D., and B.
-              Aboba, "Dynamic Authorization Extensions to Remote
-              Authentication Dial In User Service (RADIUS)", RFC 5176,
-              DOI 10.17487/RFC5176, January 2008,
-              <https://www.rfc-editor.org/info/rfc5176>.
-
-
-
-
-Henry & Lee             Expires 25 December 2024               [Page 15]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
+   [RFC6614]  Winter, S., McCauley, M., Venaas, S., and K. Wierenga,
+              "Transport Layer Security (TLS) Encryption for RADIUS",
+              RFC 6614, DOI 10.17487/RFC6614, May 2012,
+              <https://www.rfc-editor.org/info/rfc6614>.
 
    [RFC6620]  Nordmark, E., Bagnulo, M., and E. Levy-Abegnoli, "FCFS
               SAVI: First-Come, First-Served Source Address Validation
@@ -854,69 +920,55 @@ Internet-Draft                RCM Use Cases                    June 2024
               DOI 10.17487/RFC7217, April 2014,
               <https://www.rfc-editor.org/info/rfc7217>.
 
-   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
-              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
-              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+   [RFC826]   Plummer, D., "An Ethernet Address Resolution Protocol: Or
+              Converting Network Protocol Addresses to 48.bit Ethernet
+              Address for Transmission on Ethernet Hardware", STD 37,
+              RFC 826, DOI 10.17487/RFC0826, November 1982,
+              <https://www.rfc-editor.org/info/rfc826>.
 
 Appendix A.  Existing solutions
 
 A.1.  802.1X with WPA2 / WPA3
 
    At the time of association to a Wi-Fi access point, 802.1X
-   authentication coupled with WPA2 or WPA3 encryption schemes allows
-   for the mutual identification of the client device or of the user of
-   the device and an authentication authority.  The authentication
-   exchange is protected from eavesdropping.  In this scenario, the user
-   or the device identity can be obfuscated from external observers.
-   However, the authentication authority is in most cases under the
-   control of the same entity as the network access provider, thus
-   making the user or device identity visible to the network owner.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Henry & Lee             Expires 25 December 2024               [Page 16]
-
-Internet-Draft                RCM Use Cases                    June 2024
-
+   [IEEE_802.1X] authentication coupled with WPA2 or WPA3 [IEEE_802.11i]
+   encryption schemes allows for the mutual identification of the client
+   device or of the user of the device and an authentication authority.
+   Successful authentication will create a secure communication between
+   the network and the user device.  In this scenario, the user or the
+   device identity can be obfuscated from external observers.  However,
+   the authentication authority is in most cases under the control of
+   the same entity as the network access provider, thus making the user
+   or device identity visible to the network owner.
 
    This scheme is therefore well-adapted to enterprise environments,
    where a level of trust is established between the user and the
-   enterprise network operator.  In this scheme, rotation of MAC address
-   can occur through brief disconnections and reconnections (under the
-   rules of 802.11-2020).  Authentication may then need to reoccur, with
-   an associated cost of service disruption and additional load on the
-   enterprise infrastructure, and an associated benefit of limiting the
-   exposure of a continuous MAC address to external observers.  The
-   adoption of this scheme is however limited outside of the enterprise
-   environment by the requirement to install an authentication profile
-   on the end device, that would be recognized and accepted by a local
-   authentication authority and its authentication server.  Such server
-   is uncommon in a home environment, and the procedure to install a
-   profile cumbersome for most untrained users.  Remembering that 2022
-   estimations count approximatively 500 million Wi-Fi hotspots on the
-   planet, the likelihood that a user or device profile would match a
-   profile recognized by a public Wi-Fi authentication authority is also
-   fairly limited, thus restricting the adoption of this scheme for
-   public Wi-Fi as well.  Similar limitations are found in hospitality
+   enterprise network operator.  In this scheme, MAC address
+   randomization can occur through brief disconnections and
+   reconnections (under the rules of [IEEE_802.11bh]).  Authentication
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 17]
+
+Internet-Draft                RCM Use Cases                November 2024
+
+
+   may then need to reoccur, with an associated cost of service
+   disruption and additional load on the enterprise infrastructure, and
+   an associated benefit of limiting the exposure of a continuous MAC
+   address to external observers.  The adoption of this scheme is
+   however limited outside of the enterprise environment by the
+   requirement to install an authentication profile on the end device,
+   that would be recognized and accepted by a local authentication
+   authority and its authentication server.  Such server is uncommon in
+   a home environment, and the procedure to install a profile cumbersome
+   for most untrained users.  Remembering that 2022 estimations count
+   approximatively 500 million Wi-Fi hotspots on the planet, the
+   likelihood that a user or device profile would match a profile
+   recognized by a public Wi-Fi authentication authority is also fairly
+   limited, thus restricting the adoption of this scheme for public Wi-
+   Fi as well.  Similar limitations are found in hospitality
    environments.
 
 A.2.  OpenRoaming
@@ -926,12 +978,12 @@ A.2.  OpenRoaming
    intermediate trusted relay between local venues and sources of
    identity [draft-tomas-openroaming].  The federation structure also
    extends the type of authorities that can be used as identity sources
-   (compared to traditional enterprise-based 802.1X scheme for Wi-Fi),
-   and also facilitates the establishment of trust between a local venue
-   and an identity provider.  Such procedure drammatically increases the
+   (compared to traditional enterprise-based 802.1X [IEEE_802.1X] scheme
+   for Wi-Fi), and also facilitates the establishment of trust between a
+   local network and an identity provider.  Such procedure increases the
    likelihood that one or more identity profiles for the user or the
-   device will be recognized by a local venue.  At the same time,
-   authentication does not occur to the local venue, thus offering the
+   device will be recognized by a local network.  At the same time,
+   authentication does not occur to the local network, thus offering the
    possibility for the user or the device to keep their identity
    obfuscated from the local network operator, unless that operator
    specifically expresses the requirement to disclose such identity (in
@@ -942,36 +994,41 @@ A.2.  OpenRoaming
    and hospitality environments, allowing for the obfuscation of the
    identity from unauthorized entities, while also permitting mutual
    authentication between the device or the user and a trusted identity
-   provider.  Just like with standard 802.1X scheme for Wi-Fi,
-   authentication allows the establishment of WPA2 or WPA3 keys that can
-   then be used to encrypt the communication between the device and the
-   access point, thus obfuscating the traffic from observers.
+   provider.  Just like with standard 802.1X [IEEE_802.1X] scheme for
+   Wi-Fi, authentication allows the establishment of WPA2 or WPA3 keys
+   [IEEE_802.11i] that can then be used to encrypt the communication
+   between the device and the access point, thus obfuscating the traffic
+   from observers.
 
 
 
-Henry & Lee             Expires 25 December 2024               [Page 17]
+
+
+
+Henry & Lee                Expires 15 May 2025                 [Page 18]
 
-Internet-Draft                RCM Use Cases                    June 2024
+Internet-Draft                RCM Use Cases                November 2024
 
 
-   Just like in the enterprise case, rotation of MAC address can occur
+   Just like in the enterprise case, MAC address randomization can occur
    through brief disconnections and reconnections (under the rules of
-   802.11-2020).  Authentication may then need to reoccur, with an
+   [IEEE_802.11bh]).  Authentication may then need to reoccur, with an
    associated cost of service disruption and additional load on the
    venue and identity provider infrastructure, and an associated benefit
    of limiting the exposure of a continuous MAC address to external
    observers.  Limitations of this scheme include the requirement to
    first install one or more profiles on the client device.  This scheme
-   also requires the local venue network to support RADSEC and the relay
-   function, which may not be common in small hotspot networks and in
-   home environments.
+   also requires the local network to support RADSEC [RFC6614] and the
+   relay function, which may not be common in small hotspot networks and
+   in home environments.
 
    It is worth noting that, as part of collaborations between IETF
    MADINAS and WBA around OpenRoaming, some RADIUS privacy enhancements
-   have been proposed in the IETF RADEXT group.  For instance, [draft-
-   ietf-radext-deprecating-radius] describes good practices in the use
-   of Chargeable-User-Identity (CUI) between different visited networks,
-   making it better suited for Public Wi-Fi and Hospitality use cases.
+   have been proposed in the IETF RADEXT group.  For instance,
+   [I-D.ietf-radext-deprecating-radius] describes good practices in the
+   use of Chargeable-User-Identity (CUI) between different visited
+   networks, making it better suited for Public Wi-Fi and Hospitality
+   use cases.
 
 A.3.  Proprietary RCM schemes
 
@@ -983,16 +1040,16 @@ A.3.  Proprietary RCM schemes
    different MAC address in different SSIDs.
 
    Such randomization scheme enables the device to limit the duration of
-   exposure of a single MAC address to observers.  In 802.11-2020, MAC
-   address rotation is not allowed during a given association session,
-   and thus rotation of MAC address can only occur through disconnection
-   and reconnection.  Authentication may then need to reoccur, with an
-   associated cost of service disruption and additional load on the
-   venue and identity provider infrastructure, directly proportional to
-   the frequency of the rotation.  The scheme is also not intended to
-   protect from the exposure of other identifiers to the venue network
-   (e.g., DHCP option 012 [host name] visible to the network between the
-   AP and the DHCP server).
+   exposure of a single MAC address to observers.  In [IEEE_802.11bh],
+   MAC address randomization is not allowed during a given association
+   session, and thus MAC address randomization can only occur through
+   disconnection and reconnection.  Authentication may then need to
+   reoccur, with an associated cost of service disruption and additional
+   load on the venue and identity provider infrastructure, directly
+   proportional to the frequency of the randomization.  The scheme is
+   also not intended to protect from the exposure of other identifiers
+   to the venue network (e.g., DHCP option 012 [host name] visible to
+   the network between the AP and the DHCPv4 server).
 
 Authors' Addresses
 
@@ -1004,10 +1061,9 @@ Authors' Addresses
 
 
 
-
-Henry & Lee             Expires 25 December 2024               [Page 18]
+Henry & Lee                Expires 15 May 2025                 [Page 19]
 
-Internet-Draft                RCM Use Cases                    June 2024
+Internet-Draft                RCM Use Cases                November 2024
 
 
    Yiu L. Lee
@@ -1061,4 +1117,4 @@ Internet-Draft                RCM Use Cases                    June 2024
 
 
 
-Henry & Lee             Expires 25 December 2024               [Page 19]
+Henry & Lee                Expires 15 May 2025                 [Page 20]

--- a/draft-ietf-madinas-use-cases.xml
+++ b/draft-ietf-madinas-use-cases.xml
@@ -257,7 +257,7 @@
             AAA services can validate the identity of a device and use the device MAC address as a first pointer
             to the device identity (before operating further verification). Similarly, some networking devices offer
             layer-2 filtering policies that may rely on the connected MAC addresses. 802.1X-enabled 
-            <xref target="IEEE_801X"/> devices may also selectively put the interface in blocking state
+            <xref target="IEEE_802.1X"/> devices may also selectively put the interface in blocking state
             until a connecting device is authenticated. These services then use the
             MAC address as a first pointer to the device identity to allow or block data traffic. This list is not
             exhaustive. Multiple services are defined for 802.3 networks, and multiple services defined by the IEEE
@@ -341,7 +341,7 @@
             device identity with the access network devices (e.g., access point and WLAN Controller), the services beyond the
             access point in the layer-2 broadcast domain (e.g., DHCP, AAA), without fear that observers or network actors may
             access PII that would not be shared willingly. The personal device (or its user) also has confidence that its
-            identity is not shared beyond the L2 broadcast domain boundary.</li>
+            identity is not shared beyond the layer-2 broadcast domain boundary.</li>
 
             <li>Selective trust: in other environments, a device may not be willing to share a persistent identity with some
             elements of the layer-2 broadcast domain, but may be willing to share a persistent identity with other
@@ -366,7 +366,7 @@
             if it is not copied to
             another field before routing happens. The wire segment within the broadcast domain is under the control of the user,
             and is therefore usually not at risk of hosting an eavesdropper. Full trust is typically established at
-            this level among users and with the network elements. The device trusts the access point and all L2 domain entities beyond the
+            this level among users and with the network elements. The device trusts the access point and all layer-2 domain entities beyond the
             access point. However, unless the user has full access control over the physical space where the Wi-Fi transmissions can be detected,
             there is no guarantee that an eavesdropper would not be observing the communications. As such, it is common to assume that, even in
             this environment, full trust cannot be achieved.</li>
@@ -381,12 +381,12 @@
             sessions, not because it is assumed that no eavesdropper would observe the network activity, but because it is a common
             condition for the managed operations.</li>
 
-            <li>Public guest networks: public hotspots, such as in shopping malls, hotels, stores, trains stations
+            <li>Public guest networks: public hotspots, such as in shopping malls, hotels, stores, train-stations,
             and airports are typical of this environment. The guest network operator may be legally mandated to
             identify devices or users or may have the option to leave all devices and users untracked. In this
-            environment, trust is commonly not established with any element of the L2 broadcast domain (Zero trust model by default).</li>
+            environment, trust is commonly not established with any element of the layer-2 broadcast domain (Zero trust model by default).</li>
             
-            <li>Enterprises (with BYOD): users may be provided with corporate devices or
+            <li>Enterprises with Bring-Your-Own-Device (BYOD): users may be provided with corporate devices or
             may bring their own devices. The devices are not directly under the control of a corporate IT
             team. Trust may be established as the device joins the network. Some enterprise models will mandate full trust, others,
             considering the BYOD nature of the device, will allow selective trust.</li>
@@ -399,76 +399,80 @@
       </section>
       <section numbered="true" toc="default">
          <name>Network Services</name>
-         <t>
-            Different network environments provide different levels of network services, from simple to complex.
-            At its simplest level, a network can provide to a wireless connecting device basic address allocation service (DHCP)
-            and an ability to connect to the Internet (e.g., DNS service or relay, and routing in and out through a local gateway).
-            The network can also offer more advanced services, such as file storage, printing or local web service. Larger and more
-            complex networks can also incorporate a multiplicity of more advanced services, from authentication (AAA), to quality of
-            experience (QoE) monitoring and management. These services are often accompanied with network performance management services.
-            Different levels of services may call for different relationships with the device, or its user, identity. For example, there
-            is usually no need to identify the device or its user for a public network to provide a DHCP-sourced IP address to a connecting
-            station, or accept a station using its self-generated IP address (e.g., using SLAAC <xref target="RFC4862" />
-            ). However, there may be a need, in an enterprise private network, to identify devices in order to provide adapted quality
-            of services (e.g., to prioritize identified voice traffic coming from a smartphone over keepalive data coming from an
-            IoT endpoint). The same type of network may have a need to limit the effect of IP address spoofing and invalid reuse through
-            mechanisms like SAVI <xref target="RFC6620" />
-            .
+         <t>Different network environments provide different levels of network services, from simple to complex.
+         At its simplest level, a network can provide to a wireless connecting device basic address allocation service (e.g., 
+         DHCPv4 <xref target="RFC2131" /> or SLAAC <xref target="RFC4862" />)
+         and an ability to connect to the Internet (e.g., DNS service or relay, and routing in and out through a local gateway).
+         The network can also offer more advanced services, such as file storage, printing or local web service. Larger and more
+         complex networks can also incorporate a multiplicity of more advanced services, from AAA, to Quality of
+         Experience monitoring and management. These services are often accompanied with network performance management services.
+         Different levels of services may call for different relationships with the device, its user and the identity. For example, there
+         is usually no need to identify the device or its user in a public network.
+         However, there may be a need, in an enterprise private network, to associate a device to an identity in order to provide 
+         adapted quality
+         of services (e.g., to prioritize identified voice traffic coming from a smartphone over keepalive data coming from an
+         IoT endpoint). The same type of network may have a need to limit the effect of IP address spoofing and invalid reuse through
+         mechanisms like SAVI <xref target="RFC6620" />.
          </t>
          <section anchor="DevID" numbered="true" toc="default">
-         <name>Device Identification and Associated Problems</name>
-         <t>Many network functional devices offering a service to a personal
-         device use the device MAC address to maintain service continuity.</t>
+            <name>Device Identification and Associated Problems</name>
 
-         <t>Wireless access points and controllers use the MAC address to validate the device connection
-         context, including protocol capabilities, confirmation that authentication was completed, QoS or
-         security profiles, encryption key material. Some advanced access points and controllers also include
-         upper layer functions which purpose is covered below. A device changing its MAC address, without
-         another recorded device identity, would cause the access point and the controller to lose these
-         parameters. As such, the layer-2 infrastructure does not know that the device (with its new MAC address)
-         is authorized to communicate through the network. The encryption keying material is not identified
-         anymore (causing the access point to fail decrypting the device traffic, and fail selecting the
-         right key to send encrypted traffic to the device). In short, the entire context needs to be
-         rebuilt, and a new session restarted. The time consumed by this procedure breaks any flow that
-         needs continuity or short delay between packets on the device (e.g., real-time audio, video,
-         AR/VR, etc.) The 802.11i Standard recognizes that a device may leave the network and come back
-         after a short time window. As such, the standard suggests that the infrastructure should keep the
-         context for a device for a while after the device was last seen. MAC address rotation in this
-         context can cause resource exhaustion on the wireless infrastructure and the flush of contexts,
-         including for devices that are simply in temporal sleep mode.</t>
+            <t>Wireless access points and controllers use the MAC address to validate the device connection
+            context, including protocol capabilities, confirmation that authentication was completed, Quality of Service 
+            or security profiles, encryption key material. Some advanced access points and controllers also include
+            upper layer functions which purpose is covered below. A device changing its MAC address, without
+            another recorded device identity, would cause the access point and the controller to lose these
+            parameters. As such, the layer-2 infrastructure does not know that the device (with its new MAC address)
+            is authorized to communicate through the network. The encryption keying material is not identified
+            anymore (causing the access point to fail decrypting the device traffic, and fail selecting the
+            right key to send encrypted traffic to the device). In short, the entire context needs to be
+            rebuilt, and a new session restarted. The time consumed by this procedure breaks any flow that
+            needs continuity or short delay between packets on the device (e.g., real-time audio, video,
+            AR/VR, etc.) The 802.11i Standard <xref target="IEEE_802.11i"/>
+            recognizes that a device may leave the network and come back
+            after a short time window. As such, the standard suggests that the infrastructure should keep the
+            context for a device for a while after the device was last seen. MAC address rotation in this
+            context can cause resource exhaustion on the wireless infrastructure and the flush of contexts,
+            including for devices that are simply in temporal sleep mode.</t>
 
-         <t>Other devices in the layer-2 broadcast domain also use the MAC address to know whether and where to
-         forward frames. MAC rotation can cause these devices to exhaust their resources, holding in memory
-         traffic for a device which port location can no longer be found. As these infrastructure devices
-         also implement a cache (to remember the port position of each known device), too frequent MAC rotation
-         can cause resources exhaustion and the flush of older MAC addresses, including for devices that did
-         not rotate their MAC. For the RCM device, these effects translate into session discontinuity
-         and return traffic losses.</t>
+            <t>Layer-2 switches rely on ARP <xref target="RFC826"/> and NDP  <xref target="RFC4861"/>, 
+            and use the MAC address to forward frames. Aggressive MAC randanization from many devices in a short
+            time-interval may cause the layer-2 switch to exhaust its resources, holding in memory
+            traffic for a device which port location can no longer be found. As these infrastructure devices
+            also implement a cache (to remember the port position of each known device), too frequent MAC rotation
+            can cause resources exhaustion and the flush of older MAC addresses, including for devices that did
+            not rotate their MAC. For the RCM device, these effects translate into session discontinuity
+            and return traffic losses.</t>
 
-         <t>In wireless contexts, 802.1X authenticators rely on the device and user identity validation
-         provided by a AAA server to open their port to data transmission. The MAC address is used to
-         verify that the device is in the authorized list, and the associated key used to decrypt the
-         device traffic. A change in MAC address causes the port to be closed to the device data traffic
-         until the AAA server confirms the validity of the new MAC address. Therefore, MAC rotation can
-         interrupt the device traffic, and cause a strain on the AAA server.</t>
+            <t>In wireless contexts, 802.1X <xref target="IEEE_802.1X"/> authenticators rely on the device and 
+            user identity validation provided by a AAA server to change the inferface from blocking state to 
+            forwarding state. The MAC address is used to
+            verify that the device is in the authorized list, and the associated key used to decrypt the
+            device traffic. A change in MAC address causes the port to be closed to the device data traffic
+            until the AAA server confirms the validity of the new MAC address. Therefore, MAC rotation can
+            interrupt the device traffic, and cause a strain on the AAA server.</t>
 
-         <t>DHCP servers, without a unique identification of the device, lose track of which IP address is
-         validly assigned. Unless the RCM device releases the IP address before the rotation
-         occurs, DHCP servers are at risk of scope exhaustion, causing new devices (and RCM devices)
-         to fail to obtain a new IP address. Even if the RCM device releases the IP address before
-         the rotation occurs, the DHCP server typically holds the released IP address for a certain duration,
-         in case the leaving MAC would return. As the DHCP server cannot know if the release is due to a
-         temporal disconnection or a MAC rotation, the risk of scope address exhaustion exists even in cases
-         where the IP address is released.</t>
+            <t>DHCPv4 servers, without a unique identification of the device, lose track of which IP address is
+            validly assigned. Unless the RCM device releases the IP address before changing the MAC address.
+            DHCPv4 servers are at risk of scope exhaustion, causing new devices (and RCM devices)
+            to fail to obtain a new IP address. Even if the RCM device releases the IP address before
+            changing the MAC address, the DHCPv4 server typically holds the released IP address for a certain duration,
+            in case the leaving MAC would return. As the DHCPv4 server cannot know if the release is due to a
+            temporal disconnection or a MAC randamization, the risk of scope address exhaustion exists even in cases
+            where the IP address is released.</t>
 
-            <t>Network devices using self-assigned IPv6 addresses (e.g., with SLAAC defined in 
-            <xref target="RFC6620" />) use mechanisms like DAD to and ND to establish the association between a target IP address
-               and a MAC address, and may cache this association in memory. Changing the MAC address, even
-               through a disconnection-reconnection phase, without changing the IP address, may disrupt the
-               stability of these mappings, if the change occurs within the caching period.
-            </t>
+            <t>Network devices with self-assigned IPv6 addresses (e.g., with SLAAC defined in 
+            <xref target="RFC6620" />) use mechanisms like Optimistic Duplicate Address Detection (DAD)
+            <xref target="RFC4429"/> and NDP <xref target="RFC4861"/>  
+            to establish the association between a target IP address
+            and a MAC address, and may cache this association in memory. Changing the MAC address, even
+            through a disconnection-reconnection phase, without changing the IP address, may disrupt the
+            stability of these mappings, if the change occurs within the caching period. Similarly, static IP assignement 
+            will break if the MAC address changes without updating the mapping.</t>
+
             <t>Routers keep track of which MAC address is on which interface. MAC rotation can cause MAC
-        address cache exhaustion, but also the need for frequent ARP and inverse ARP exchanges.</t>
+            address cache exhaustion, but also the need for frequent ARP and inverse ARP exchanges.</t>
+
             <t>In residential settings (environments type A in section  <xref target="Environments" />), 
             policies can be in place to control the
             traffic of some devices (e.g., parental control or block-list filters). These policies are often based on the device
@@ -484,22 +488,20 @@
             MAC address rotation, real time support is only possible if the user is able to provide the
             current MAC address. Service improvement support is not possible if the MAC address that
             the device had at the (past) time of the reported issue is not known at the time the issue
-		      is reported.</t>
+            is reported.</t>
             
             <t>In industrial environments, policies are associated to each group of objects, including IoT.
-              MAC address rotation may prevent an IoT device from being identified properly, thus leading to
-              network quarantine and disruption of operations.</t>
+            MAC address rotation may prevent an IoT device from being identified properly, thus leading to
+            network quarantine and disruption of operations.</t>
          </section>
+
          <section numbered="true" toc="default">
             <name>Use Cases</name>
-            <t>
-               <xref target="DevID" />
-               discusses different environments, different settings, and the expectations of
-  users and network operators.
-               <xref target="scenario_table" />
-               summarizes the expected degree of trust, network
-  admin responsibility, complexity of supported network services and network support expectation from the user for the different use cases.
-            </t>
+            <t><xref target="DevID" /> discusses different environments, different settings, and the expectations of
+            users and network operators.<xref target="scenario_table" />
+            ummarizes the expected degree of trust, network admin responsibility, complexity of supported network services 
+            and network support expectation from the user for the different use cases.</t>
+
             <table anchor="scenario_table" align="center">
                <name>Use Cases</name>
                <thead>
@@ -513,47 +515,41 @@
                </thead>
                <tbody>
                   <tr>
-                     <td align="center">Home</td>
+                     <td align="center">Residential settings under the control of the user</td>
                      <td align="center">Medium</td>
                      <td align="center">User</td>
                      <td align="center">Medium</td>
                      <td align="center">Low</td>
                   </tr>
                   <tr>
-                     <td align="center">Managed Residential</td>
+                     <td align="center">Managed residential settings</td>
                      <td align="center">Medium</td>
                      <td align="center">IT</td>
                      <td align="center">Medium</td>
                      <td align="center">Medium</td>
                   </tr>
                   <tr>
-                     <td align="center">Campus (BYOD)</td>
-                     <td align="center">Medium</td>
-                     <td align="center">IT</td>
-                     <td align="center">Complex</td>
-                     <td align="center">Medium</td>
-                  </tr>
-                  <tr>
-                     <td align="center">Enterprise (MDM)</td>
-                     <td align="center">High</td>
-                     <td align="center">IT</td>
-                     <td align="center">Complex</td>
-                     <td align="center">High</td>
-                  </tr>
-                  <tr>
-                     <td align="center">Hospitality</td>
-                     <td align="center">Low</td>
-                     <td align="center">IT</td>
-                     <td align="center">Simple</td>
-                     <td align="center">Medium</td>
-                  </tr>
-                  <tr>
-                     <td align="center">Public WiFi</td>
+                     <td align="center">Public guest networks</td>
                      <td align="center">Low</td>
                      <td align="center">ISP</td>
                      <td align="center">Simple</td>
                      <td align="center">Low</td>
                   </tr>
+                  <tr>
+                     <td align="center">Enterprises with Bring-Your-Own-Device (BYOD)</td>
+                     <td align="center">Medium</td>
+                     <td align="center">IT</td>
+                     <td align="center">Complex</td>
+                     <td align="center">Medium</td>
+                  </tr>
+                  <tr>
+                     <td align="center">Managed enterprises</td>
+                     <td align="center">High</td>
+                     <td align="center">IT</td>
+                     <td align="center">Complex</td>
+                     <td align="center">High</td>
+                  </tr>
+
                </tbody>
             </table>
             <t>For example: a Home network is sometimes considered to be trusted and safe, where users
@@ -602,9 +598,10 @@
          <?rfc include="reference.RFC.826.xml" ?>
          <?rfc include="reference.RFC.2131.xml" ?>
          <?rfc include="reference.RFC.3539.xml" ?>
-         <?rfc include="reference.RFC.4941.xml" ?>
+         <?rfc include="reference.RFC.4429.xml" ?>   
          <?rfc include="reference.RFC.4861.xml" ?>        
          <?rfc include="reference.RFC.4862.xml" ?>
+         <?rfc include="reference.RFC.4941.xml" ?>
          <?rfc include="reference.RFC.6620.xml" ?>
          <?rfc include="reference.RFC.7217.xml" ?>
 
@@ -618,13 +615,13 @@
          <seriesInfo name="IEEE 802" value="" />
       </reference>
 
-      <reference anchor="IEEE_801X" >
+      <reference anchor="IEEE_802.1X" >
          <front>
-            <title>IEEE 801X-2020 - IEEE Standard for Local and Metropolitan Area Networks--Port-Based Network Access Control</title>
+            <title>IEEE 802.1X-2020 - IEEE Standard for Local and Metropolitan Area Networks--Port-Based Network Access Control</title>
             <author initials="" surname="" fullname="IEEE 802.1X WG - 802 LAN/MAN Standards Committee"></author>
             <date month="" year="2020"/>
          </front>
-         <seriesInfo name="IEEE 801X" value="" />
+         <seriesInfo name="IEEE 802.1X" value="" />
 	   </reference>   
 
       <reference anchor="IEEE_802E" >
@@ -645,6 +642,18 @@
          <seriesInfo name="IEEE 802.11" value="" />
 	   </reference>
 
+      <reference anchor="IEEE_802.11i" >
+         <front>
+            <title>IEEE 802.11i-2004 - IEEE Standard for information technology-Telecommunications and information exchange 
+               between systems-Local and metropolitan area networks-Specific requirements-Part 11: Wireless LAN Medium 
+               Access Control (MAC) and Physical Layer (PHY) specifications: Amendment 6: Medium Access Control (MAC) 
+               Security Enhancements</title>
+            <author initials="" surname="" fullname="IEEE 802.11i WG - 802 LAN/MAN Standards Committee"></author>
+            <date month="" year="2004"/>
+         </front>
+         <seriesInfo name="IEEE 802.11i" value="" />
+	   </reference>   
+
 	   <reference anchor="draft-tomas-openroaming" >
          <front>
             <title>WBA OpenRoaming Wireless Federation</title>
@@ -655,32 +664,67 @@
       </reference>
 
 
-
 </references>
 
 
   <section anchor="Solutions" numbered="true" toc="default">
       <name>Existing solutions</name>
       
-	     <section numbered="true" toc="default">
-	      <name>802.1X with WPA2 / WPA3</name>
+	   <section numbered="true" toc="default">
+	   <name>802.1X with WPA2 / WPA3</name>
 	      
-	      <t> At the time of association to a Wi-Fi access point, 802.1X authentication coupled with WPA2 or WPA3 encryption schemes allows for the mutual identification of the client device or of the user of the device and an authentication authority. The authentication exchange is protected from eavesdropping. In this scenario, the user or the device identity can be obfuscated from external observers. However, the authentication authority is in most cases under the control of the same entity as the network access provider, thus making the user or device identity visible to the network owner. </t>
+	   <t>At the time of association to a Wi-Fi access point, 802.1X <xref target="IEEE 802.1X"/> authentication coupled 
+      with WPA2 or WPA3 <xref target="IEEE_802.11i"/>
+      encryption schemes allows for the mutual identification of the client device or of the user of the device and an 
+      authentication authority. The authentication exchange is protected from eavesdropping. In this scenario, the 
+      user or the device identity can be obfuscated from external observers. However, the authentication authority is in 
+      most cases under the control of the same entity as the network access provider, thus making the user or device identity 
+      visible to the network owner. </t>
 	      
-	      <t>This scheme is therefore well-adapted to enterprise environments, where a level of trust is established between the user and the enterprise network operator. In this scheme, rotation of MAC address can occur through brief disconnections and reconnections (under the rules of 802.11-2020). Authentication may then need to reoccur, with an associated cost of service disruption and additional load on the enterprise infrastructure, and an associated benefit of limiting the exposure of a continuous MAC address to external observers. The adoption of this scheme is however limited outside of the enterprise environment by the requirement to install an authentication profile on the end device, that would be recognized and accepted by a local authentication authority and its authentication server. Such server is uncommon in a home environment, and the procedure to install a profile cumbersome for most untrained users. Remembering that 2022 estimations count approximatively 500 million Wi-Fi hotspots on the planet, the likelihood that a user or device profile would match a profile recognized by a public Wi-Fi authentication authority is also fairly limited, thus restricting the adoption of this scheme for public Wi-Fi as well. Similar limitations are found in hospitality environments.
-	    </t>
+	   <t>This scheme is therefore well-adapted to enterprise environments, where a level of trust is established between the user 
+      and the enterprise network operator. In this scheme, rotation of MAC address can occur through brief disconnections and 
+      reconnections (under the rules of 802.11-2020). Authentication may then need to reoccur, with an associated cost of service 
+      disruption and additional load on the enterprise infrastructure, and an associated benefit of limiting the exposure of a 
+      continuous MAC address to external observers. The adoption of this scheme is however limited outside of the enterprise 
+      environment by the requirement to install an authentication profile on the end device, that would be recognized and accepted 
+      by a local authentication authority and its authentication server. Such server is uncommon in a home environment, and the 
+      procedure to install a profile cumbersome for most untrained users. Remembering that 2022 estimations count approximatively 
+      500 million Wi-Fi hotspots on the planet, the likelihood that a user or device profile would match a profile recognized by 
+      a public Wi-Fi authentication authority is also fairly limited, thus restricting the adoption of this scheme for public 
+      Wi-Fi as well. Similar limitations are found in hospitality environments. </t>
 	
 		</section>
-	     <section anchor="OpenRoaming" numbered="true" toc="default">
-	      <name>OpenRoaming</name>
-<t> In order to alleviate some of the limitations listed above, the Wireless Broadband Alliance (WBA) OpenRoaming Standard introduces an intermediate trusted relay between local venues and sources of identity  <xref target="draft-tomas-openroaming" />. The federation structure also extends the type of authorities that can be used as identity sources (compared to traditional enterprise-based 802.1X scheme for Wi-Fi), and also facilitates the establishment of trust between a local venue and an identity provider. Such procedure drammatically increases the likelihood that one or more identity profiles for the user or the device will be recognized by a local venue. At the same time, authentication does not occur to the local venue, thus offering the possibility for the user or the device to keep their identity obfuscated from the local network operator, unless that operator specifically expresses the requirement to disclose such identity (in which case the user has the option to accept or decline the connection and associated identity exposure).
-</t>
+	     
+      <section anchor="OpenRoaming" numbered="true" toc="default">
+	   <name>OpenRoaming</name>
+      <t> In order to alleviate some of the limitations listed above, the Wireless Broadband Alliance (WBA) OpenRoaming 
+      Standard introduces an intermediate trusted relay between local venues and sources of identity  
+      <xref target="draft-tomas-openroaming" />. The federation structure also extends the type of authorities that can be 
+      used as identity sources (compared to traditional enterprise-based 802.1X scheme for Wi-Fi), and also facilitates the 
+      establishment of trust between a local venue and an identity provider. Such procedure drammatically increases the likelihood 
+      that one or more identity profiles for the user or the device will be recognized by a local venue. At the same time, 
+      authentication does not occur to the local venue, thus offering the possibility for the user or the device to keep 
+      their identity obfuscated from the local network operator, unless that operator specifically expresses the requirement to 
+      disclose such identity (in which case the user has the option to accept or decline the connection and associated identity exposure).</t>
 
-<t> The OpenRoaming scheme therefore seems well-adapted to public Wi-Fi and hospitality environments, allowing for the obfuscation of the identity from unauthorized entities, while also permitting mutual authentication between the device or the user and a trusted identity provider. Just like with standard 802.1X scheme for Wi-Fi, authentication allows the establishment of WPA2 or WPA3 keys that can then be used to encrypt the communication between the device and the access point, thus obfuscating the traffic from observers. </t>
+      <t>The OpenRoaming scheme therefore seems well-adapted to public Wi-Fi and hospitality environments, allowing for the 
+      obfuscation of the identity from unauthorized entities, while also permitting mutual authentication between the device or the user 
+      and a trusted identity provider. Just like with standard 802.1X scheme for Wi-Fi, authentication allows the establishment of WPA2 
+      or WPA3 keys that can then be used to encrypt the communication between the device and the access point, thus obfuscating the traffic 
+      from observers. </t>
 	
-<t> Just like in the enterprise case, rotation of MAC address can occur through brief disconnections and reconnections (under the rules of 802.11-2020). Authentication may then need to reoccur, with an associated cost of service disruption and additional load on the venue and identity provider infrastructure, and an associated benefit of limiting the exposure of a continuous MAC address to external observers. Limitations of this scheme include the requirement to first install one or more profiles on the client device. This scheme also requires the local venue network to support RADSEC and the relay function, which may not be common in small hotspot networks and in home environments.</t>
-<t>It is worth noting that, as part of collaborations between IETF MADINAS and WBA around OpenRoaming, some RADIUS privacy enhancements have been proposed in the IETF RADEXT group. For instance, [draft-ietf-radext-deprecating-radius] describes good practices in the use of Chargeable-User-Identity (CUI) between different visited networks, making it better suited for Public Wi-Fi and Hospitality use cases.</t>
-	
+      <t>Just like in the enterprise case, rotation of MAC address can occur through brief disconnections and reconnections 
+      (under the rules of 802.11-2020). Authentication may then need to reoccur, with an associated cost of service disruption and 
+      additional load on the venue and identity provider infrastructure, and an associated benefit of limiting the exposure of a 
+      continuous MAC address to external observers. Limitations of this scheme include the requirement to first install one or more profiles 
+      on the client device. This scheme also requires the local venue network to support RADSEC and the relay function, which may not be common 
+      in small hotspot networks and in home environments.</t>
+
+      <t>It is worth noting that, as part of collaborations between IETF MADINAS and WBA around OpenRoaming, some RADIUS privacy 
+      enhancements have been proposed in the IETF RADEXT group. For instance, [draft-ietf-radext-deprecating-radius] describes 
+      good practices in the use of Chargeable-User-Identity (CUI) between different visited networks, making it better suited for 
+      Public Wi-Fi and Hospitality use cases.</t>
+
 	      
 	 </section>
 	

--- a/draft-ietf-madinas-use-cases.xml
+++ b/draft-ietf-madinas-use-cases.xml
@@ -11,7 +11,7 @@
 <!-- used by XSLT processors -->
 <!-- For a complete list and description of processing instructions (PIs),
     please see http://xml.resource.org/authoring/README.html. -->
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-ietf-madinas-use-cases-10" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" category="info" docName="draft-ietf-madinas-use-cases-11" ipr="trust200902" obsoletes="" updates="" submissionType="IETF" xml:lang="en" tocInclude="true" tocDepth="4" symRefs="true" sortRefs="true" version="3">
    <!-- xml2rfc v2v3 conversion 2.38.1 -->
    <!-- category values: std, bcp, info, exp, and historic
     ipr values: trust200902, noModificationTrust200902, noDerivativesTrust200902,
@@ -22,8 +22,8 @@
    <front>
       <!-- The abbreviated title is used in the page header - it is only necessary if the
         full title is longer than 39 characters -->
-      <title abbrev="RCM Use Cases">Randomized and Changing MAC Address Use Cases</title>
-      <seriesInfo name="Internet-Draft" value="draft-ietf-madinas-use-cases-10" />
+      <title abbrev="RCM Use Cases">Randomized and Changing MAC Address: Context, Network Impacts and Use Cases</title>
+      <seriesInfo name="Internet-Draft" value="draft-ietf-madinas-use-cases-11" />
       <!-- add 'role="editor"' below for the editors if appropriate -->
       <!-- Another author who claims to be an editor -->
       <author fullname="Jerome Henry" initials="J" surname="Henry">
@@ -71,234 +71,257 @@
         keywords will be used for the search engine. -->
       <abstract>
          <t>To limit the privacy issues created by the association between a device, its traffic, its location and its user,
-      client and client OS vendors have started implementing MAC address rotation. When such a rotation
+      client and client Operation System vendors have started implementing MAC address rotation. When such a randomization
       happens, some in-network states may break, which may affect network connectivity and user experience.
-      At the same time, devices may continue using other stable identifiers, defeating the MAC rotation purposes.
-      This document lists various network environments and a set of network services that may be affected
+      At the same time, devices may continue using other stable identifiers, defeating the MAC rotation purposes.</t>
+      
+         <t>This document lists various network environments and a set of network services that may be affected
       by such rotation. This document then examines settings where the user experience may be affected by in-network
       state disruption. Last, this document examines
       solutions to maintain user privacy while preserving user quality of experience and network
       operation efficiency.</t>
       </abstract>
    </front>
+
    <middle>
       <section numbered="true" toc="default">
          <name>Introduction</name>
-	 <t>IEEE 802.11 (or 'Wi-Fi') <xref target="IEEE_802.11"/> technology has revolutionized
-   communications and become the
-   preferred, and sometimes the only technology used by
-   devices such as laptops, tablets and Internet-of-Thing (IoT)
-   devices.  Wi-Fi is an over-the-air technology, attackers with surveillance equipment can "monitor" WLAN packets and
-   track the activity of WLAN devices.  Once the association between a
-   device and its user is made, identifying the device and its activity
-   is sufficient to deduce information about what the user is doing,
-   without the user consent.</t>
+         <t>IEEE 802.11 (or 'Wi-Fi') <xref target="IEEE_802.11"/> technology has revolutionized
+         communications and become the
+         preferred, and sometimes the only technology used by
+         devices such as laptops, tablets and Internet-of-Thing (IoT)
+         devices.  Wi-Fi is an over-the-air technology, attackers with surveillance equipment can "monitor" WLAN packets and
+         track the activity of WLAN devices. It is also possible for attackers to "monitor" the WLAN packers behind the Wi-Fi
+         Access Point (AP) over the wired Ethernet. Once the association between a device and its user is made, identifying the 
+         device and its activity is sufficient to deduce information about what the user is doing,
+         without the user consent.</t>
 
-         <t>To reduce the risks of correlation between a device activity and its owner's, multiple client and client OS 
-      vendors have started to implement Randomized and Changing MAC addresses (RCM). By randomizing the MAC address,
-      the persistent association between a given
-      traffic flow and a single device is made more difficult, assuming no other visible unique identifiers or stable patterns are in use. When individual devices are no longer easily identifiable, it also becomes difficult to associate a series of network flows with a particular individual using one particular device.</t>
+         <t>To reduce the risks of correlation between a device activity and its owner's, multiple clients, and client OS 
+         vendors have started to implement Randomized and Changing MAC addresses (RCM). By randomizing the MAC address,
+         it becomes harder to use the MAC address to construct persistent assocation between a flow of data packets and a device, 
+         assuming no other visible unique identifiers or stable patterns are in use. When individual devices are no longer easily identifiable, it also becomes difficult 
+         to associate a series of network flows with a particular individual using one particular device.</t>
 
          <t>However, such address change may affect the user experience and the efficiency of legitimate
-      network operations. For a long time, network designers and implementers relied on the assumption that a given machine,
-      in a network implementing <xref target="IEEE_802"/> technologies, would be represented by a unique network MAC address that would not
-      change over time, despite the existence of tools to flush out the MAC address to bypass
-      some network policies. When this assumption is broken, network communication may be disrupted.
-      For example, sessions established between the end-device and network services may break and
-      packets in transit may suddenly be lost. If multiple clients implement
-      fast-paced RCM rotations without coordination with network services, these network services may become over-solicited.</t>
+         network operations. For a long time, network designers and implementers relied on the assumption that a given machine,
+         in a network implementing <xref target="IEEE_802"/> technologies, would be represented by a unique network MAC address that would not
+         change over time, despite the existence of tools to flush out the MAC address to bypass
+         some network policies. When this assumption is broken, network communication may be disrupted.
+         For example, sessions established between the end-device and network services may break and
+         packets in transit may suddenly be lost. If multiple clients implement
+         fast-paced RCM rotations without coordination with network services, these network services may become over-solicited.</t>
 
-         <t>At the same time, some network services rely on the end station (as defined by the <xref target="IEEE_802"/> Standard) providing an identifier, which can be
-      the MAC address or another value. If the client implements MAC rotation but continues sending the same static
-      identifier, then the association between a stable identifier and the station continues despite the RCM scheme.
-      There may be environments where such continued association is desirable, but others where the user privacy has
-      more value than any continuity of network service state.</t>
+         <t>At the same time, some network services rely on the end station (as defined by the <xref target="IEEE_802"/> Standard) providing 
+         an identifier, which can be
+         the MAC address or another value. If the client implements MAC rotation but continues sending the same static
+         identifier, then the association between a stable identifier and the station continues despite the RCM scheme.
+         There may be environments where such continued association is desirable, but others where the user privacy has
+         more value than any continuity of network service state.</t>
 
-         <t>There is a need to enumerate services that may be
-      affected by RCM, and evaluate possible solutions to maintain both the quality of user experience
-      and network efficiency while RCM happens and user privacy is reinforced. This document
-      presents such assessment and recommendations.</t>
+         <t>It could be useful to enumerate services that may be
+         affected by RCM, and evaluate possible solutions to maintain both the quality of user experience
+         and network efficiency while RCM happens and user privacy is reinforced. This document
+         presents such assessment and recommendations.</t>
+
+         <t>This document is organized as follows. 
+         </t>
 
       </section>
       <!-- This PI places the pagebreak correctly (before the section title) in the text output. -->
       <section numbered="true" toc="default">
          <name>MAC Address as Identity: User vs. Device</name>
-         <t>Any device member of a network implementing IEEE 802 technologies
-      includes several operating layers. Among them, the Media
-      Access Control (MAC) layer defines rules to control how the device accesses the shared medium. In a
-      network where a machine can communicate with one or more other machines, one such rule is that each
-      machine needs to be identified, either as the target destination of a message, or as the source of a
-      message (and thus the target destination of the answer). Initially intended as a 48-bit (6 octets)
-      value in the first versions of the <xref target="IEEE_802"/> Standard, other Standards under
-      the <xref target="IEEE_802"/> umbrella
-      then allowed this address to take an extended
-      format of 64 bits (8 octets), thus enabling a larger number of MAC addresses to coexist as the
-      802 technologies became widely adopted.</t>
+         <t>The Media Access Control (MAC) layer of IEEE 802 technologies defines rules to control 
+         how a device accesses the shared medium. In a
+         network where a machine can communicate with one or more other machines, one such rule is that each
+         machine needs to be identified, either as the target destination of a message, or as the source of a
+         message (and thus the target destination of the answer). Initially intended as a 48-bit (6 octets)
+         value in the first versions of the <xref target="IEEE_802"/> Standard, other Standards under
+         the <xref target="IEEE_802"/> umbrella
+         then allowed this address to take an extended
+         format of 64 bits (8 octets), thus enabling a larger number of MAC addresses to coexist as the
+         802 technologies became widely adopted.</t>
 
          <t>Regardless of the address length, different networks have different needs, and several bits of
-      the first octet are reserved for specific purposes. In particular, the first bit is used to identify
-      the destination address either as an individual (bit set to 0) or a group address (bit set to 1). The
-      second bit, called the Universally or Locally Administered (U/L) Address Bit, indicates whether the address
-      has been assigned by a local or universal administrator. Universally administered addresses have this
-      bit set to 0. If this bit is set to 1, the entire address (i.e., 48 bits) has been locally administered
-      (clause 8.4 of <xref target="IEEE_802"/>).</t>
+         the first octet are reserved for specific purposes. In particular, the first bit is used to identify
+         the destination address either as an individual (bit set to 0) or a group address (bit set to 1). The
+         second bit, called the Universally or Locally Administered (U/L) Address Bit, indicates whether the address
+         has been assigned by a local or universal administrator. Universally administered addresses have this
+         bit set to 0. If this bit is set to 1, the entire address (i.e., 48 bits) has been locally administered
+         (clause 8.4 of <xref target="IEEE_802"/>).</t>
 
          <t>The intent of this provision is important for the present document. The <xref target="IEEE_802"/>
-          Standard recognized
-      that some devices may never change their attachment network and thus would not need a
-      globally unique MAC address to prevent address collision against any other device in any other network.
-      To accommodate for this requirement, the second bit of the MAC
-      address first octet was designed to express whether the address was intended
-      to be globally unique, or locally unique. The address allocation method was not
-      defined in the Standard in this later case, but the same clause
-      defined that an address should be unique so as to avoid collision with any other device attached to the same network.</t>
+         Standard recognized
+         that some devices (e.g., Smart Thermostat) may never change their attachment network and thus would not need a
+         globally unique MAC address to prevent address collision against any other device in any other network. The 
+         Universally or Locally Administered Address Bit is defined to signal the network that the MAC Address is locally
+         significant. IEEE didn't define the MAC Address allocation schema when L=1. It states the address must be unique
+         in the same broadcast domain.</t>
 
          <t>It is also important to note that the purpose of the Universal version of the address was
-      to avoid collisions and confusion, as any machine could connect to any network, and each machine needs
-      to determine if it is the intended destination of a message or its response. Clause 8.4 of <xref target="IEEE_802"/>
-      reminds network designers and operators that all potential members of a network need to have a unique
-      identifier in that network (if they are going to coexist in the network without confusion on which
-      machine is the source or destination or any message). The advantage of a universal address is
-      that a node with such an address can be attached to any Local Area Network (LAN) in the world with an assurance that its
-      address is unique in that network.</t>
+         to avoid collisions and confusion, as any machine could connect to any network, and each machine needs
+         to determine if it is the intended destination of a message or its response. Clause 8.4 of <xref target="IEEE_802"/>
+         reminds network designers and operators that all potential members of a network need to have a unique
+         identifier in that network (if they are going to coexist in the network without confusion on which
+         machine is the source or destination or any message). The advantage of a universally administrated address is
+         that a node with such an address can be attached to any Local Area Network (LAN) in the world with an assurance that its
+         address is unique in that network.</t>
 
          <t>With the rapid development of wireless technologies and mobile devices, this scenario became
-      very common. With a vast majority of networks implementing <xref target="IEEE_802"/> radio technologies at
-      the access, the MAC address of a wireless device can appear anywhere on the planet and collisions
-      should still be avoided. However, the same evolution brought the distinction between two types of
-      devices that the <xref target="IEEE_802"/> Standard generally referred to as ‘nodes in a network’. Their definition is
-      found in the <xref target="IEEE_802E" /> Recommended Practice stated in Section 6.2 of <xref target="IEEE_802"/>. One type is a shared
-      service device, which
-      functions are used by a number of people large enough that the device itself, its functions or its
-      traffic cannot be associated with a single or small group of people. Examples of such devices include
-      switches in a dense network, IEEE 802.11 (WLAN) access points in a crowded airport, task-specific
-      (e.g., barcode scanners) devices, etc. Another type is a personal device, which is a machine, a node,
-      primarily used by a single person or small group of people, and so that any identification of the
-      device or its traffic can also be associated to the identification of the primary user or their traffic.
-      Quite naturally, the identification of the device is trivial if the device expresses a
-      universally unique MAC address. Then, the detection of elements directly or indirectly identifying
-      the user of the device (Personally Identifiable Information, or PII) is sufficient to tie the
-      universal MAC address to a user. Then, any detection of traffic that can be associated to the
-      device becomes also associated with the known user of that device (Personally Correlated
-      Information, or PCI).</t>
+         very common. With a vast majority of networks implementing <xref target="IEEE_802"/> radio technologies at
+         the access, the MAC address of a wireless device can appear anywhere on the planet and collisions
+         should still be avoided. However, the same evolution brought the distinction between two types of
+         devices that the <xref target="IEEE_802"/> Standard generally referred to as ‘nodes in a network’. Their definition is
+         found in the <xref target="IEEE_802E" /> Recommended Practice stated in Section 6.2 of <xref target="IEEE_802"/>.</t>
+         
+            <ol spacing="normal" type="1">
+               <li> Shared Service Device, which
+               functions are used by a number of people large enough that the device itself, its functions or its
+               traffic cannot be associated with a single or small group of people. Examples of such devices include
+               switches in a dense network, IEEE 802.11 (WLAN) access points in a crowded airport, task-specific
+               (e.g., barcode scanners) devices, etc.</li>
 
-         <t>This possible identification or association presents a serious privacy issue,
-      especially with wireless technologies. For most of them, and in particular for 802.11, the
-      source and destination MAC addresses are not encrypted even in networks that implement encryption
-      (so that each machine can easily detect if it is the intended target of the message before attempting
-      to decrypt its content, and also identify the transmitter, so as to use the right decryption key when multiple
-      unicast keys are in effect).</t>
+               <li> Personal Device, which is a machine, a node,
+               primarily used by a single person or small group of people, and so that any identification of the
+               device or its traffic can also be associated to the identification of the primary user or their traffic.
+               </li>
+            </ol>
+
+            <t>The identification of the device is trivial if the device expresses a
+            universally unique MAC address. Then, the detection of elements directly or indirectly identifying
+            the user of the device (Personally Identifiable Information, or PII) is sufficient to tie the
+            universal MAC address to a user. Then, any detection of traffic that can be associated to the
+            device becomes also associated with the known user of that device (Personally Correlated
+            Information, or PCI).</t>
+
+         <section anchor="privacy" numbered="true" toc="default">
+         <name>Privacy of MAC Address</name>
+         <t>This possible identification or association presents a privacy issue,
+         especially with wireless technologies. For most of them, and in particular for 802.11, the
+         source and destination MAC addresses are not encrypted even in networks that implement encryption
+         (so that each machine can easily detect if it is the intended target of the message before attempting
+         to decrypt its content, and also identify the transmitter, so as to use the right decryption key when multiple
+         unicast keys are in effect).</t>
 
          <t>This identification of the user associated to a node was clearly not the intent of the
-      802 MAC address. A logical solution to remove this association is to use a locally administered
-      address instead, and change the address in a fashion that prevents a continuous association between
-      one MAC address and some PII. However, other network devices on the
-      same LAN implementing a MAC layer also expect each device to be associated to a MAC address that would
-      persist over time. When a device changes
-      its MAC address, other devices on the same LAN may fail to recognize that the same machine is attempting
-      to communicate with them. Additionally, multiple layers implemented at upper OSI layers have been designed
-      with the assumption that each node on the LAN, using these services, would have a MAC address that would
-      stay the same over time, and that this document calls a 'persistent' MAC address. This
-      assumption sometimes adds to the PII confusion, for example in the case of Authentication, Association
-      and Accounting (AAA) services authenticating
-      the user of a machine and associating the authenticated user to the device MAC address. Other services
-      solely focus on the machine (e.g., DHCP), but still expect each device to use a persistent MAC address,
-      for example to re-assign the same IP address to a returning device.
-      Changing the MAC address may disrupt these services.</t>
+         802 MAC address. A logical solution to remove this association is to use a locally administered
+         address instead, and change the address in a fashion that prevents a continuous association between
+         one MAC address and some PII. However, other network devices on the
+         same LAN implementing a MAC layer also expect each device to be associated to a MAC address that would
+         persist over time. When a device changes
+         its MAC address, other devices on the same LAN may fail to recognize that the same machine is attempting
+         to communicate with them. Additionally, multiple layers implemented at upper OSI layers have been designed
+         with the assumption that each node on the LAN, using these services, would have a MAC address that would
+         stay the same over time, and that this document calls a 'persistent' MAC address. This
+         assumption sometimes adds to the PII confusion, for example in the case of Authentication, Association
+         and Accounting (AAA) services <xref target="RFC3539"/> authenticating
+         the user of a machine and associating the authenticated user to the device MAC address. Other services
+         solely focus on the machine (e.g., DHCPv4 <xref target="RFC2131"/>), but still expect each device to use a persistent MAC address,
+         for example to re-assign the same IP address to a returning device.
+         Changing the MAC address may disrupt these services.</t>
+         </section>
+
       </section>
 
-      <section numbered="true" toc="default">
+      <section anchor="actor" numbered="true" toc="default">
          <name>The Actors: Network Functional Entities and Human Entities</name>
          <t>The risk of service disruption is thus weighted against the privacy benefits. However, the plurality
-      of actors involved in the exchanges tends to blur the boundaries of what privacy should be
-      protected against. It might therefore be useful to list the actors associated to the network exchanges,
-      either because they actively participate to these exchanges, or because they can observe them.
-      Some actors are functional entities, some others are humans (or related) entities.</t>
+         of actors involved in the exchanges tends to blur the boundaries of what privacy should be
+         protected against. It might therefore be useful to list the actors associated to the network exchanges,
+         either because they actively participate to these exchanges, or because they can observe them.
+         Some actors are functional entities, some others are humans (or related) entities.</t>
+
          <section numbered="true" toc="default">
             <name>Network Functional Entities</name>
             <t>Network communications based on IEEE 802 technologies commonly rely on station identifiers based on a
-              MAC address. This MAC address is utilized by several types of network functional entitities (entities, like applications or devices, that provide a service related to network operations).</t>
+              MAC address. This MAC address is utilized by several types of network functional entitities (entities, 
+              like applications or devices, that provide a service related to network operations).</t>
+
             <t>Wireless access network infrastructure devices (e.g., WLAN access points or controllers): these
-        devices participate in IEEE 802 LAN operations. As such, they need to identify each machine as a source
-        or destination so as to successfully continue exchanging frames. Part of the identification includes
-        recording, and adapting to, devices communication capabilities (e.g., support for specific protocols).
-        As a device changes its network attachment (roams) from one access point to another, the access points can
-        exchange contextual information (e.g., device MAC, keying material) allowing the device session to
-        continue seamlessly. These access points can also inform devices further in the wired network about
-        the roam, to ensure that OSI model Layer 2 frames are redirected to the new device access point.</t>
-            <t>Other network devices operating at the MAC layer: many wireless network access devices
-        (e.g., IEEE 802.11 access points) are conceived as Layer 2 devices, and as such they bridge a frame from
-        one medium (e.g., IEEE 802.11 or Wi-Fi) to another (e.g., IEEE 802.3 or Ethernet). This means that a wireless
-        device MAC address often exists on the wire beyond the wireless access device. Devices connected to
-        this wire also implement IEEE 802 technologies, and as such operate on the expectation that each device is
-        associated to a MAC address that persists for the duration of continuous exchanges. For example, switches
-        and bridges associate MAC addresses to individual ports (so as to know which port to send a frame
-        intended for a particular MAC address). Similarly, authentication, authorization and accounting
-        (AAA) services can validate the identity of a device and use the device MAC address as a first pointer
-        to the device identity (before operating further verification). Similarly, some networking devices offer
-        Layer-2 filtering policies that may rely on the connected MAC addresses. 802.1X-enabled devices may also selectively
-        block the data portion of a port until a connecting device is authenticated. These services then use the
-        MAC address as a first pointer to the device identity to allow or block data traffic. This list is not
-        exhaustive. Multiple services are defined for 802.3 networks, and multiple services defined by the IEEE
-        802.1 working group are also applicable to 802.3 networks. Wireless access points may also connect to
-        other mediums than 802.3, which also implements mechanism under the umbrella of the general 802 Standard,
-        and therefore expect the unique and persistent association of a MAC address to a device.</t>
-            <t>Network devices operating at upper layers: some network devices provide functions and services
-        above the MAC layer. Some of them also operate a MAC layer function: for example, routers provide
-        IP forwarding services, but rely on the device MAC address to create the appropriate frame structure.
-        Other devices and services operate at upper layers, but also rely upon the 802 principle of unique
-        MAC-to-device mapping. For example, DHCP services with IPv4 commonly provide a single IP address per MAC
-        address (they do not assign more than one IP address per MAC address, and assign a new IP address to each
-        new requesting MAC address). ARP and reverse-ARP services commonly expect that, once an IP-to-MAC mapping
-        has been established, this mapping is valid and unlikely to change for the cache lifetime. DHCP services with IPv6
-        commonly do not assign the same IP address to two different requesting MAC addresses. Hybrid services,
-        such as EoIP, also assume stability of the device-to-MAC-and-IP mapping for the duration of a given session.</t>
+            devices participate in IEEE 802 LAN operations. As such, they need to identify each machine as a source
+            or destination so as to successfully continue exchanging frames. Part of the identification includes
+            recording, and adapting to, devices communication capabilities (e.g., support for specific protocols).
+            As a device changes its network attachment (roams) from one access point to another, the access points can
+            exchange contextual information (e.g., device MAC, keying material) allowing the device session to
+            continue seamlessly. These access points can also inform devices further in the wired network about
+            the roam, to ensure that layer-2 frames are redirected to the new device access point.</t>
+
+            <ol spacing="normal" type="1">
+            <li> Wireless Access Point: Many wireless network access devices
+            (e.g., IEEE 802.11 access points) are conceived as layer-2 devices, and as such they bridge a frame from
+            one medium (e.g., IEEE 802.11 or Wi-Fi) to another (e.g., IEEE 802.3 or Ethernet). This means that a wireless
+            device MAC address often exists on the wire beyond the wireless access device. Devices connected to
+            this wire also implement IEEE 802.3 technologies, and as such operate on the expectation that each device is
+            associated to a MAC address that persists for the duration of continuous exchanges. For example, switches
+            and bridges associate MAC addresses to individual ports (so as to know which port to send a frame
+            intended for a particular MAC address). Similarly,
+            AAA services can validate the identity of a device and use the device MAC address as a first pointer
+            to the device identity (before operating further verification). Similarly, some networking devices offer
+            layer-2 filtering policies that may rely on the connected MAC addresses. 802.1X-enabled 
+            <xref target="IEEE_801X"/> devices may also selectively put the interface in blocking state
+            until a connecting device is authenticated. These services then use the
+            MAC address as a first pointer to the device identity to allow or block data traffic. This list is not
+            exhaustive. Multiple services are defined for 802.3 networks, and multiple services defined by the IEEE
+            802.1 working group are also applicable to 802.3 networks. Wireless access points may also connect to
+            other mediums than 802.3, which also implements mechanism under the umbrella of the general 802 Standard,
+            and therefore expect the unique and persistent association of a MAC address to a device.</li>
+
+            <li>Address Resolution Protocol and Neighbor Discovery Protocol: Address Resolution Protocl (ARP) 
+               <xref target="RFC826"/> and Neighbor Discovery Protocol (NDP) <xref target="RFC4861"/> use MAC address
+               to create the mapping of an IP address to a MAC address for packet forwarding. 
+               If a device changed a MAC address without 
+               notifying the layer-2 switch it is connected to, network connectivity would be interrupted until the layer-2
+               switch learned the new MAC address and updated the table.  
+            </li>
+         </ol>
          </section>
+
          <section numbered="true" toc="default">
             <name>Human-related Entities</name>
-            <t>Networks do no operate without humans actively involved at one or more points of the network lifecycle.
-              Humans may actively participate to the network structure and operations, or be observers.</t>
+            <t>Humans may actively participate to the network structure and operations, or be observers at any point
+            of network lifecycle. Humans could be wireless device users or people operating the wireless networks.</t>
 
-            <t>Over the air (OTA) observers: as the transmitting or receiving MAC address is usually not encrypted
-        in wireless 802-technologies exchanges, and as any protocol-compatible device in range of the signal
-        can read the frame header, OTA observers are able to read individual transmissions MAC addresses. Some
-        wireless technologies also support techniques to establish distances or positions, allowing the observer,
-        in some cases, to uniquely associate the MAC address to a physical device and it associated location.
-        It can happen that an OTA observer has a legitimate reason to monitor a particular device, for example
-        for IT support operations. However, it is difficult to control if another actor also monitors the same
-        station with the goal of obtaining PII or PCI.</t>
+            <ol spacing="normal" type="1">
+               <li>Over the air (OTA) observers: As the transmitting or receiving MAC address is usually not encrypted
+               in wireless 802-technologies exchanges, and as any protocol-compatible device in range of the signal
+               can read the frame header, OTA observers are able to read individual transmissions MAC addresses. Some
+               wireless technologies also support techniques to establish distances or positions, allowing the observer,
+               in some cases, to uniquely associate the MAC address to a physical device and it associated location.
+               It can happen that an OTA observer has a legitimate reason to monitor a particular device, for example
+               for IT support operations. However, it is difficult to control if another actor also monitors the same
+               station with the goal of obtaining PII or PCI.</li>
 
-            <t>Wireless access network operators: some wireless access networks are only provided
-        devices matching specific requirements, such as device type (e.g., IoT-only networks, factory operational
-        networks). Therefore, operators can attempt to identify the devices (or the users) connecting to the
-        networks under their care. They can use the MAC address to represent an identified device.</t>
+               <li>Wireless access network operators: some wireless access networks are only provided
+               devices matching specific requirements, such as device type (e.g., IoT-only networks, factory operational
+               networks). Therefore, operators can attempt to identify the devices (or the users) connecting to the
+               networks under their care. They can use the MAC address to represent an identified device.</li>
 
-            <t>Network access providers: wireless access networks are often considered beyond the first 2 layers of
-        the OSI model. For example, several regulatory or legislative bodies can group all OSI layers into
-        their functional effect of allowing network communication between machines. In this context, entities
-        operating access networks can see their liability associated to the activity of devices communicating
-        through the networks that these entities operate. In other contexts, operators assign network
-        resources based on contractual conditions (e.g., fee, bandwidth fair share). In these scenarios,
-        these operators may attempt to identify the devices and the users of their networks. They can use the
-        MAC address to represent an identified device.</t>
+               <li>Network access providers: wireless access networks are often considered beyond the first 2 layers of
+               the OSI model. For example, several regulatory or legislative bodies can group all OSI layers into
+               their functional effect of allowing network communication between machines. In this context, entities
+               operating access networks can see their liability associated to the activity of devices communicating
+               through the networks that these entities operate. In other contexts, operators assign network
+               resources based on contractual conditions (e.g., fee, bandwidth fair share). In these scenarios,
+               these operators may attempt to identify the devices and the users of their networks. They can use the
+               MAC address to represent an identified device.</li>
 
-            <t>Over the wire internal (OTWi) observers: because the device wireless MAC address continues to be
-        present over the wire if the infrastructure connection device (e.g., access point) functions as a Layer
-        2 bridge, observers may be positioned over the wire and read transmission MAC addresses. Such capability
-        supposes that the observer has access to the wired segment of the broadcast domain where the frames
-        are exchanged. In most networks, such capability requires physical access to an infrastructure wired
-        device in the broadcast domain (e.g., switch closet), and is therefore not accessible to all.</t>
+               <li>Over the wire internal (OTWi) observers: because the device wireless MAC address continues to be
+               present over the wire if the infrastructure connection device (e.g., access point) functions as a layer-2 
+               bridge, observers may be positioned over the wire and read transmission MAC addresses. Such capability
+               supposes that the observer has access to the wired segment of the broadcast domain where the frames
+               are exchanged. A Broadcast Domain is a logical division of a network where a device in the divison 
+               can send, receive and monitor data frames from all devices in the same division.  
+               In most networks, such capability requires physical access to an infrastructure wired
+               device in the broadcast domain (e.g., switch closet), and is therefore not accessible to all.</li>
 
-            <t>Over the wired external (OTWe) observers: beyond the broadcast domain, frames headers are removed
-        by a routing device, and a new Layer 2 header is added before the frame is transmitted to the next
-        segment. The personal device MAC address is not visible anymore, unless a mechanism copies the MAC
-        address into a field that can be read while the packet travels onto the next segment (e.g., pre-
-               <xref target="RFC4941" />
-               and pre-
-               <xref target="RFC7217" />
+               <li>Over the wired external (OTWe) observers: beyond the broadcast domain, frames headers are removed
+               by a routing device, and a new layer-2 header is added before the frame is transmitted to the next
+               segment. The personal device MAC address is not visible anymore, unless a mechanism copies the MAC
+               address into a field that can be read while the packet travels onto the next segment (e.g., pre-
+               <xref target="RFC4941" /> and pre-<xref target="RFC7217" />
                IPv6 addresses built from the MAC address). Therefore, unless this last condition exists,
-        OTWe observers are not able to see the device MAC address.
-            </t>
+               OTWe observers are not able to see the device MAC address.
+               </li>
+            </ol>
          </section>
       </section>
 
@@ -312,54 +335,66 @@
         for a service in an environment where trust has not been established. Trust is not a binary currency.
         Thus it is useful to distinguish what trust a personal device may establish with the different entities
         at play in a network domain where a MAC address may be visible:</t>
+
          <ol spacing="normal" type="1">
             <li>Full trust: there are environments where a personal device establishes a trust relationship and can share a persistent
             device identity with the access network devices (e.g., access point and WLAN Controller), the services beyond the
-            access point in the L2 broadcast domain (e.g., DHCP, AAA), without fear that observers or network actors may
+            access point in the layer-2 broadcast domain (e.g., DHCP, AAA), without fear that observers or network actors may
             access PII that would not be shared willingly. The personal device (or its user) also has confidence that its
             identity is not shared beyond the L2 broadcast domain boundary.</li>
+
             <li>Selective trust: in other environments, a device may not be willing to share a persistent identity with some
-            elements of the Layer 2 broadcast domain, but may be willing to share a persistent identity with other
+            elements of the layer-2 broadcast domain, but may be willing to share a persistent identity with other
             elements. That persistent identity may or may not be the same for different
             services.</li>
+
             <li>Zero trust: in other environments, a device may not be willing to share any persistent identity with any local entity
             reachable through the AP, and may express a temporal identity to each of them. That temporal
             identity may or not be the same for different services.</li>
          </ol>
       </section>
+
       <section anchor="Environments" numbered="true" toc="default">
          <name>Environments</name>
          <t>The trust relationship depends on the relationship between the user of a personal device
-        and the operator of a network service that the personal device may use. Thus, it is useful to observe the typical trust structure of common environments:</t>
-         <ol spacing="normal" type="A">
+         and the operator of a network service that the personal device may use. Thus, it is useful to observe the typical trust 
+         structure of common environments:</t>
+        
+        <ol spacing="normal" type="A">
             <li>Residential settings under the control of the user: this is typical of a home network with Wi-Fi in the LAN and
-          Internet connection. In this environment, traffic over the Internet does not expose the MAC adddress of internal devices if it is not copied to
-          another field before routing happens. The wire segment within the broadcast domain is under the control of the user,
-          and is therefore usually not at risk of hosting an eavesdropper. Full trust is typically established at
-	        this level among users and with the network elements. The device trusts the access point and all L2 domain entities beyond the
-          access point. However, unless the user has full access control over the physical space where the Wi-Fi transmissions can be detected,
-          there is no guarantee that an eavesdropper would not be observing the communications. As such, it is common to assume that, even in
-          this environment, full trust cannot be achieved.</li>
+            Internet connection. In this environment, traffic over the Internet does not expose the MAC adddress of internal device
+            if it is not copied to
+            another field before routing happens. The wire segment within the broadcast domain is under the control of the user,
+            and is therefore usually not at risk of hosting an eavesdropper. Full trust is typically established at
+            this level among users and with the network elements. The device trusts the access point and all L2 domain entities beyond the
+            access point. However, unless the user has full access control over the physical space where the Wi-Fi transmissions can be detected,
+            there is no guarantee that an eavesdropper would not be observing the communications. As such, it is common to assume that, even in
+            this environment, full trust cannot be achieved.</li>
+
             <li>Managed residential settings: examples of this type of environment include shared living facilities
-          and other collective environments where an operator manages the network for the residents. The OTA
-          exposure is similar to that of a home. A number of devices larger than in a standard home may be
-          present, and the operator may be requested to provide IT support to the residents. Therefore, the
-          operator may need to identify a device activity in real time, but may also need to analyze logs so
-          as to understand a past reported issue. For both activities, a device identification associated to the
-          session is needed. Full trust is often established in this environment, at the scale of a series of a few
-          sessions, not because it is assumed that no eavesdropper would observe the network activity, but because it is a common
-          condition for the managed operations.</li>
+            and other collective environments where an operator manages the network for the residents. The OTA
+            exposure is similar to that of a home. A number of devices larger than in a standard home may be
+            present, and the operator may be requested to provide IT support to the residents. Therefore, the
+            operator may need to identify a device activity in real time, but may also need to analyze logs so
+            as to understand a past reported issue. For both activities, a device identification associated to the
+            session is needed. Full trust is often established in this environment, at the scale of a series of a few
+            sessions, not because it is assumed that no eavesdropper would observe the network activity, but because it is a common
+            condition for the managed operations.</li>
+
             <li>Public guest networks: public hotspots, such as in shopping malls, hotels, stores, trains stations
-          and airports are typical of this environment. The guest network operator may be legally mandated to
-          identify devices or users or may have the option to leave all devices and users untracked. In this
-          environment, trust is commonly not established with any element of the L2 broadcast domain (Zero trust model by default).</li>
+            and airports are typical of this environment. The guest network operator may be legally mandated to
+            identify devices or users or may have the option to leave all devices and users untracked. In this
+            environment, trust is commonly not established with any element of the L2 broadcast domain (Zero trust model by default).</li>
+            
             <li>Enterprises (with BYOD): users may be provided with corporate devices or
-          may bring their own devices. The devices are not directly under the control of a corporate IT
-          team. Trust may be established as the device joins the network. Some enterprise models will mandate full trust, others,
-          considering the BYOD nature of the device, will allow selective trust.</li>
+            may bring their own devices. The devices are not directly under the control of a corporate IT
+            team. Trust may be established as the device joins the network. Some enterprise models will mandate full trust, others,
+            considering the BYOD nature of the device, will allow selective trust.</li>
+               
             <li>Managed enterprises: in this environment, users are typically provided with corporate devices,
-          and all connected devices are managed, for example through a Mobile Device Management (MDM) profile
-          installed on the device. Full trust is created as the MDM profile is installed.</li>
+            and all connected devices are managed, for example through a Mobile Device Management (MDM) profile
+            installed on the device. Full trust is created as the MDM profile is installed.</li>
+
          </ol>
       </section>
       <section numbered="true" toc="default">
@@ -381,73 +416,76 @@
             .
          </t>
          <section anchor="DevID" numbered="true" toc="default">
-            <name>Device Identification and Associated Problems</name>
-            <t>Many network functional devices offering a service to a personal
-        device use the device MAC address to maintain service continuity.</t>
+         <name>Device Identification and Associated Problems</name>
+         <t>Many network functional devices offering a service to a personal
+         device use the device MAC address to maintain service continuity.</t>
 
-            <t>Wireless access points and controllers use the MAC address to validate the device connection
-        context, including protocol capabilities, confirmation that authentication was completed, QoS or
-        security profiles, encryption key material. Some advanced access points and controllers also include
-        upper layer functions which purpose is covered below. A device changing its MAC address, without
-        another recorded device identity, would cause the access point and the controller to lose these
-        parameters. As such, the Layer 2 infrastructure does not know that the device (with its new MAC address)
-        is authorized to communicate through the network. The encryption keying material is not identified
-        anymore (causing the access point to fail decrypting the device traffic, and fail selecting the
-        right key to send encrypted traffic to the device). In short, the entire context needs to be
-        rebuilt, and a new session restarted. The time consumed by this procedure breaks any flow that
-        needs continuity or short delay between packets on the device (e.g., real-time audio, video,
-        AR/VR, etc.) The 802.11i Standard recognizes that a device may leave the network and come back
-        after a short time window. As such, the standard suggests that the infrastructure should keep the
-        context for a device for a while after the device was last seen. MAC address rotation in this
-        context can cause resource exhaustion on the wireless infrastructure and the flush of contexts,
-        including for devices that are simply in temporal sleep mode.</t>
+         <t>Wireless access points and controllers use the MAC address to validate the device connection
+         context, including protocol capabilities, confirmation that authentication was completed, QoS or
+         security profiles, encryption key material. Some advanced access points and controllers also include
+         upper layer functions which purpose is covered below. A device changing its MAC address, without
+         another recorded device identity, would cause the access point and the controller to lose these
+         parameters. As such, the layer-2 infrastructure does not know that the device (with its new MAC address)
+         is authorized to communicate through the network. The encryption keying material is not identified
+         anymore (causing the access point to fail decrypting the device traffic, and fail selecting the
+         right key to send encrypted traffic to the device). In short, the entire context needs to be
+         rebuilt, and a new session restarted. The time consumed by this procedure breaks any flow that
+         needs continuity or short delay between packets on the device (e.g., real-time audio, video,
+         AR/VR, etc.) The 802.11i Standard recognizes that a device may leave the network and come back
+         after a short time window. As such, the standard suggests that the infrastructure should keep the
+         context for a device for a while after the device was last seen. MAC address rotation in this
+         context can cause resource exhaustion on the wireless infrastructure and the flush of contexts,
+         including for devices that are simply in temporal sleep mode.</t>
 
-            <t>Other devices in the Layer 2 broadcast domain also use the MAC address to know whether and where to
-        forward frames. MAC rotation can cause these devices to exhaust their resources, holding in memory
-        traffic for a device which port location can no longer be found. As these infrastructure devices
-        also implement a cache (to remember the port position of each known device), too frequent MAC rotation
-        can cause resources exhaustion and the flush of older MAC addresses, including for devices that did
-        not rotate their MAC. For the RCM device, these effects translate into session discontinuity
-        and return traffic losses.</t>
+         <t>Other devices in the layer-2 broadcast domain also use the MAC address to know whether and where to
+         forward frames. MAC rotation can cause these devices to exhaust their resources, holding in memory
+         traffic for a device which port location can no longer be found. As these infrastructure devices
+         also implement a cache (to remember the port position of each known device), too frequent MAC rotation
+         can cause resources exhaustion and the flush of older MAC addresses, including for devices that did
+         not rotate their MAC. For the RCM device, these effects translate into session discontinuity
+         and return traffic losses.</t>
 
-            <t>In wireless contexts, 802.1X authenticators rely on the device and user identity validation
-        provided by a AAA server to open their port to data transmission. The MAC address is used to
-        verify that the device is in the authorized list, and the associated key used to decrypt the
-        device traffic. A change in MAC address causes the port to be closed to the device data traffic
-        until the AAA server confirms the validity of the new MAC address. Therefore, MAC rotation can
-        interrupt the device traffic, and cause a strain on the AAA server.</t>
+         <t>In wireless contexts, 802.1X authenticators rely on the device and user identity validation
+         provided by a AAA server to open their port to data transmission. The MAC address is used to
+         verify that the device is in the authorized list, and the associated key used to decrypt the
+         device traffic. A change in MAC address causes the port to be closed to the device data traffic
+         until the AAA server confirms the validity of the new MAC address. Therefore, MAC rotation can
+         interrupt the device traffic, and cause a strain on the AAA server.</t>
 
-            <t>DHCP servers, without a unique identification of the device, lose track of which IP address is
-        validly assigned. Unless the RCM device releases the IP address before the rotation
-        occurs, DHCP servers are at risk of scope exhaustion, causing new devices (and RCM devices)
-        to fail to obtain a new IP address. Even if the RCM device releases the IP address before
-        the rotation occurs, the DHCP server typically holds the released IP address for a certain duration,
-        in case the leaving MAC would return. As the DHCP server cannot know if the release is due to a
-        temporal disconnection or a MAC rotation, the risk of scope address exhaustion exists even in cases
-		where the IP address is released.</t>
-            <t>
-               Network devices using self-assigned IPv6 addresses (e.g., with SLAAC defined in
-               <xref target="RFC6620" />
-               ) use mechanisms like DAD to and ND to establish the association between a target IP address
+         <t>DHCP servers, without a unique identification of the device, lose track of which IP address is
+         validly assigned. Unless the RCM device releases the IP address before the rotation
+         occurs, DHCP servers are at risk of scope exhaustion, causing new devices (and RCM devices)
+         to fail to obtain a new IP address. Even if the RCM device releases the IP address before
+         the rotation occurs, the DHCP server typically holds the released IP address for a certain duration,
+         in case the leaving MAC would return. As the DHCP server cannot know if the release is due to a
+         temporal disconnection or a MAC rotation, the risk of scope address exhaustion exists even in cases
+         where the IP address is released.</t>
+
+            <t>Network devices using self-assigned IPv6 addresses (e.g., with SLAAC defined in 
+            <xref target="RFC6620" />) use mechanisms like DAD to and ND to establish the association between a target IP address
                and a MAC address, and may cache this association in memory. Changing the MAC address, even
                through a disconnection-reconnection phase, without changing the IP address, may disrupt the
                stability of these mappings, if the change occurs within the caching period.
             </t>
             <t>Routers keep track of which MAC address is on which interface. MAC rotation can cause MAC
         address cache exhaustion, but also the need for frequent ARP and inverse ARP exchanges.</t>
-            <t>In residential settings (environments type A in section  <xref target="Environments" />), policies can be in place to control the
-        traffic of some devices (e.g., parental control or block-list filters). These policies are often based on the device
-        MAC address. Rotation of the MAC address removes the possibility for such control.</t>
+            <t>In residential settings (environments type A in section  <xref target="Environments" />), 
+            policies can be in place to control the
+            traffic of some devices (e.g., parental control or block-list filters). These policies are often based on the device
+            MAC address. Rotation of the MAC address removes the possibility for such control.</t>
+            
             <t>In residential settings (environments type A) and in enterprises (environments types D and E),
-        device recognition and ranging may be used for IoT-related functionalities (door unlock, preferred
-        light and temperature configuration, etc.) These functions often rely on the detection of the
-        device wireless MAC address. MAC address rotation breaks the services based on such model.</t>
+            device recognition and ranging may be used for IoT-related functionalities (door unlock, preferred
+            light and temperature configuration, etc.) These functions often rely on the detection of the
+            device wireless MAC address. MAC address rotation breaks the services based on such model.</t>
+            
             <t>In managed residential settings (environments types B) and in enterprises (environments types
-        D and E), the network operator is often requested to provide IT support. With
-        MAC address rotation, real time support is only possible if the user is able to provide the
-        current MAC address. Service improvement support is not possible if the MAC address that
-        the device had at the (past) time of the reported issue is not known at the time the issue
-		is reported.</t>
+            D and E), the network operator is often requested to provide IT support. With
+            MAC address rotation, real time support is only possible if the user is able to provide the
+            current MAC address. Service improvement support is not possible if the MAC address that
+            the device had at the (past) time of the reported issue is not known at the time the issue
+		      is reported.</t>
+            
             <t>In industrial environments, policies are associated to each group of objects, including IoT.
               MAC address rotation may prevent an IoT device from being identified properly, thus leading to
               network quarantine and disruption of operations.</t>
@@ -532,7 +570,7 @@
 
             <t>On the other end of the spectrum, Public Wi-Fi is often considered to be completely untrusted,
               where a user has no expectation of being able to trust other users or any actor inside or
-              outside of the Layer 2 domain. Privacy is the number one concern for the user. Most users
+              outside of the layer-2 domain. Privacy is the number one concern for the user. Most users
               connecting to Public Wi-Fi only require simple Internet connectivity service, and expect
 		    only limited to no technical support.</t>
 	    <t>There are existing technical solutions that address some of the requirements from several of the use cases listed above. 
@@ -561,54 +599,60 @@
     filing system or remote ones accessed by http (http://domain/dir/... ).-->
      
       <references title="Informative References">
+         <?rfc include="reference.RFC.826.xml" ?>
+         <?rfc include="reference.RFC.2131.xml" ?>
+         <?rfc include="reference.RFC.3539.xml" ?>
          <?rfc include="reference.RFC.4941.xml" ?>
+         <?rfc include="reference.RFC.4861.xml" ?>        
          <?rfc include="reference.RFC.4862.xml" ?>
          <?rfc include="reference.RFC.6620.xml" ?>
-         <?rfc include="reference.RFC.5176.xml" ?>
          <?rfc include="reference.RFC.7217.xml" ?>
-         <?rfc include="reference.RFC.8174.xml" ?>
-
-	     
 
 
-	  <reference anchor="IEEE_802" >
-           <front>
-              <title>IEEE Std 802 - IEEE Standard for Local and Metropolitan Area Networks: Overview and Architecture</title>
-              <author initials="" surname="IEEE 802" fullname="IEEE 802"></author>
-              <date month="" year="2014"/>
-           </front>
-          <seriesInfo name="IEEE 802" value="" />
-        </reference>
+	   <reference anchor="IEEE_802" >
+         <front>
+            <title>IEEE Std 802 - IEEE Standard for Local and Metropolitan Area Networks: Overview and Architecture</title>
+            <author initials="" surname="IEEE 802" fullname="IEEE 802"></author>
+            <date month="" year="2014"/>
+         </front>
+         <seriesInfo name="IEEE 802" value="" />
+      </reference>
 
+      <reference anchor="IEEE_801X" >
+         <front>
+            <title>IEEE 801X-2020 - IEEE Standard for Local and Metropolitan Area Networks--Port-Based Network Access Control</title>
+            <author initials="" surname="" fullname="IEEE 802.1X WG - 802 LAN/MAN Standards Committee"></author>
+            <date month="" year="2020"/>
+         </front>
+         <seriesInfo name="IEEE 801X" value="" />
+	   </reference>   
 
-         <reference anchor="IEEE_802E" >
-              <front>
-          <title>IEEE 802E-2020 - IEEE Recommended Practice for Privacy Considerations for IEEE 802 Technologies</title>
-      <author initials="" surname="IEEE 802.1 WG - 802 LAN/MAN architecture" fullname="IEEE 802.1 WG - 802 LAN/MAN architecture">
-          </author>
-          <date month="" year="2020"/>
-        </front>
-        <seriesInfo name="IEEE 802E" value="" />
-	</reference>
+      <reference anchor="IEEE_802E" >
+         <front>
+            <title>IEEE 802E-2020 - IEEE Recommended Practice for Privacy Considerations for IEEE 802 Technologies</title>
+            <author initials="" surname="" fullname="IEEE 802E WG - 802 LAN/MAN Standards Committee"></author>
+            <date month="" year="2020"/>
+         </front>
+         <seriesInfo name="IEEE 802E" value="" />
+	   </reference>   
 
- 	<reference anchor="IEEE_802.11" >
-              <front>
-          <title>IEEE 802.11-2020 -  Wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) Specifications</title>
-	  <author initials="" surname="IEEE 802.11 WG - 802 LAN/MAN Standards Committee" fullname="IEEE 802.11 WG - 802 LAN/MAN Standards Committee">
-          </author>
-          <date month="" year="2020"/>
-        </front>
-        <seriesInfo name="IEEE 802.11" value="" />
-	</reference>
+ 	   <reference anchor="IEEE_802.11" >
+         <front>
+            <title>IEEE 802.11-2020 -  Wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) Specifications</title>
+	         <author initials="" surname="" fullname="IEEE 802.11 WG - 802 LAN/MAN Standards Committee"></author>
+            <date month="" year="2020"/>
+         </front>
+         <seriesInfo name="IEEE 802.11" value="" />
+	   </reference>
 
-	 <reference anchor="draft-tomas-openroaming" >
-           <front>
-              <title>WBA OpenRoaming Wireless Federation</title>
-              <author initials="B" surname="Tomas" fullname="B Tomas"></author>
-              <date month="" year="2024"/>
-           </front>
-          <seriesInfo name="IETF" value="" />
-        </reference>
+	   <reference anchor="draft-tomas-openroaming" >
+         <front>
+            <title>WBA OpenRoaming Wireless Federation</title>
+            <author initials="B" surname="Tomas" fullname="B Tomas"></author>
+            <date month="" year="2024"/>
+         </front>
+         <seriesInfo name="IETF" value="" />
+      </reference>
 
 
 

--- a/draft-ietf-madinas-use-cases.xml
+++ b/draft-ietf-madinas-use-cases.xml
@@ -71,12 +71,12 @@
         keywords will be used for the search engine. -->
       <abstract>
          <t>To limit the privacy issues created by the association between a device, its traffic, its location and its user,
-      client and client Operation System vendors have started implementing MAC address rotation. When such a randomization
+      client and client Operation System vendors have started implementing MAC address randomization. When such a randomization
       happens, some in-network states may break, which may affect network connectivity and user experience.
-      At the same time, devices may continue using other stable identifiers, defeating the MAC rotation purposes.</t>
+      At the same time, devices may continue using other stable identifiers, defeating the MAC address randomization purposes.</t>
       
          <t>This document lists various network environments and a set of network services that may be affected
-      by such rotation. This document then examines settings where the user experience may be affected by in-network
+      by such randomization. This document then examines settings where the user experience may be affected by in-network
       state disruption. Last, this document examines
       solutions to maintain user privacy while preserving user quality of experience and network
       operation efficiency.</t>
@@ -98,8 +98,9 @@
 
          <t>To reduce the risks of correlation between a device activity and its owner's, multiple clients, and client OS 
          vendors have started to implement Randomized and Changing MAC addresses (RCM). By randomizing the MAC address,
-         it becomes harder to use the MAC address to construct persistent assocation between a flow of data packets and a device, 
-         assuming no other visible unique identifiers or stable patterns are in use. When individual devices are no longer easily identifiable, it also becomes difficult 
+         it becomes harder to use the MAC address to construct persistent association between a flow of data packets and a device, 
+         assuming no other visible unique identifiers or stable patterns are in use. When individual devices are no longer easily 
+         identifiable, it also becomes difficult 
          to associate a series of network flows with a particular individual using one particular device.</t>
 
          <t>However, such address change may affect the user experience and the efficiency of legitimate
@@ -109,11 +110,11 @@
          some network policies. When this assumption is broken, network communication may be disrupted.
          For example, sessions established between the end-device and network services may break and
          packets in transit may suddenly be lost. If multiple clients implement
-         fast-paced RCM rotations without coordination with network services, these network services may become over-solicited.</t>
+         fast-paced MAC address randomization without coordination with network services, these network services may become over-solicited.</t>
 
          <t>At the same time, some network services rely on the end station (as defined by the <xref target="IEEE_802"/> Standard) providing 
          an identifier, which can be
-         the MAC address or another value. If the client implements MAC rotation but continues sending the same static
+         the MAC address or another value. If the client implements MAC address randomization but continues sending the same static
          identifier, then the association between a stable identifier and the station continues despite the RCM scheme.
          There may be environments where such continued association is desirable, but others where the user privacy has
          more value than any continuity of network service state.</t>
@@ -233,7 +234,7 @@
          <section numbered="true" toc="default">
             <name>Network Functional Entities</name>
             <t>Network communications based on IEEE 802 technologies commonly rely on station identifiers based on a
-              MAC address. This MAC address is utilized by several types of network functional entitities (entities, 
+              MAC address. This MAC address is utilized by several types of network functional entities (entities, 
               like applications or devices, that provide a service related to network operations).</t>
 
             <t>Wireless access network infrastructure devices (e.g., WLAN access points or controllers): these
@@ -265,7 +266,7 @@
             other mediums than 802.3, which also implements mechanism under the umbrella of the general 802 Standard,
             and therefore expect the unique and persistent association of a MAC address to a device.</li>
 
-            <li>Address Resolution Protocol and Neighbor Discovery Protocol: Address Resolution Protocl (ARP) 
+            <li>Address Resolution Protocol and Neighbor Discovery Protocol: Address Resolution Protocol (ARP) 
                <xref target="RFC826"/> and Neighbor Discovery Protocol (NDP) <xref target="RFC4861"/> use MAC address
                to create the mapping of an IP address to a MAC address for packet forwarding. 
                If a device changed a MAC address without 
@@ -308,7 +309,7 @@
                present over the wire if the infrastructure connection device (e.g., access point) functions as a layer-2 
                bridge, observers may be positioned over the wire and read transmission MAC addresses. Such capability
                supposes that the observer has access to the wired segment of the broadcast domain where the frames
-               are exchanged. A Broadcast Domain is a logical division of a network where a device in the divison 
+               are exchanged. A Broadcast Domain is a logical division of a network where a device in the division 
                can send, receive and monitor data frames from all devices in the same division.  
                In most networks, such capability requires physical access to an infrastructure wired
                device in the broadcast domain (e.g., switch closet), and is therefore not accessible to all.</li>
@@ -362,7 +363,7 @@
         
         <ol spacing="normal" type="A">
             <li>Residential settings under the control of the user: this is typical of a home network with Wi-Fi in the LAN and
-            Internet connection. In this environment, traffic over the Internet does not expose the MAC adddress of internal device
+            Internet connection. In this environment, traffic over the Internet does not expose the MAC address of internal device
             if it is not copied to
             another field before routing happens. The wire segment within the broadcast domain is under the control of the user,
             and is therefore usually not at risk of hosting an eavesdropper. Full trust is typically established at
@@ -431,25 +432,26 @@
             AR/VR, etc.) The 802.11i Standard <xref target="IEEE_802.11i"/>
             recognizes that a device may leave the network and come back
             after a short time window. As such, the standard suggests that the infrastructure should keep the
-            context for a device for a while after the device was last seen. MAC address rotation in this
+            context for a device for a while after the device was last seen. MAC address randomization in this
             context can cause resource exhaustion on the wireless infrastructure and the flush of contexts,
             including for devices that are simply in temporal sleep mode.</t>
 
             <t>Layer-2 switches rely on ARP <xref target="RFC826"/> and NDP  <xref target="RFC4861"/>, 
-            and use the MAC address to forward frames. Aggressive MAC randanization from many devices in a short
+            and use the MAC address to forward frames. Aggressive MAC randamization from many devices in a short
             time-interval may cause the layer-2 switch to exhaust its resources, holding in memory
             traffic for a device which port location can no longer be found. As these infrastructure devices
-            also implement a cache (to remember the port position of each known device), too frequent MAC rotation
+            also implement a cache (to remember the port position of each known device), too frequent MAC address
+            randomization
             can cause resources exhaustion and the flush of older MAC addresses, including for devices that did
             not rotate their MAC. For the RCM device, these effects translate into session discontinuity
             and return traffic losses.</t>
 
             <t>In wireless contexts, 802.1X <xref target="IEEE_802.1X"/> authenticators rely on the device and 
-            user identity validation provided by a AAA server to change the inferface from blocking state to 
+            user identity validation provided by a AAA server to change the interface from blocking state to 
             forwarding state. The MAC address is used to
             verify that the device is in the authorized list, and the associated key used to decrypt the
             device traffic. A change in MAC address causes the port to be closed to the device data traffic
-            until the AAA server confirms the validity of the new MAC address. Therefore, MAC rotation can
+            until the AAA server confirms the validity of the new MAC address. Therefore, MAC address randomization can
             interrupt the device traffic, and cause a strain on the AAA server.</t>
 
             <t>DHCPv4 servers, without a unique identification of the device, lose track of which IP address is
@@ -458,7 +460,7 @@
             to fail to obtain a new IP address. Even if the RCM device releases the IP address before
             changing the MAC address, the DHCPv4 server typically holds the released IP address for a certain duration,
             in case the leaving MAC would return. As the DHCPv4 server cannot know if the release is due to a
-            temporal disconnection or a MAC randamization, the risk of scope address exhaustion exists even in cases
+            temporal disconnection or a MAC randomization, the risk of scope address exhaustion exists even in cases
             where the IP address is released.</t>
 
             <t>Network devices with self-assigned IPv6 addresses (e.g., with SLAAC defined in 
@@ -467,31 +469,31 @@
             to establish the association between a target IP address
             and a MAC address, and may cache this association in memory. Changing the MAC address, even
             through a disconnection-reconnection phase, without changing the IP address, may disrupt the
-            stability of these mappings, if the change occurs within the caching period. Similarly, static IP assignement 
+            stability of these mappings, if the change occurs within the caching period. Similarly, static IP assignment 
             will break if the MAC address changes without updating the mapping.</t>
 
-            <t>Routers keep track of which MAC address is on which interface. MAC rotation can cause MAC
+            <t>Routers keep track of which MAC address is on which interface. MAC address randomization can cause MAC
             address cache exhaustion, but also the need for frequent ARP and inverse ARP exchanges.</t>
 
             <t>In residential settings (environments type A in section  <xref target="Environments" />), 
             policies can be in place to control the
             traffic of some devices (e.g., parental control or block-list filters). These policies are often based on the device
-            MAC address. Rotation of the MAC address removes the possibility for such control.</t>
+            MAC address. MAC address randomization removes the possibility for such control.</t>
             
             <t>In residential settings (environments type A) and in enterprises (environments types D and E),
             device recognition and ranging may be used for IoT-related functionalities (door unlock, preferred
             light and temperature configuration, etc.) These functions often rely on the detection of the
-            device wireless MAC address. MAC address rotation breaks the services based on such model.</t>
+            device wireless MAC address. MAC address randomization breaks the services based on such model.</t>
             
             <t>In managed residential settings (environments types B) and in enterprises (environments types
             D and E), the network operator is often requested to provide IT support. With
-            MAC address rotation, real time support is only possible if the user is able to provide the
+            MAC address randomization, real time support is only possible if the user is able to provide the
             current MAC address. Service improvement support is not possible if the MAC address that
             the device had at the (past) time of the reported issue is not known at the time the issue
             is reported.</t>
             
             <t>In industrial environments, policies are associated to each group of objects, including IoT.
-            MAC address rotation may prevent an IoT device from being identified properly, thus leading to
+            MAC address randomization may prevent an IoT device from being identified properly, thus leading to
             network quarantine and disruption of operations.</t>
          </section>
 
@@ -499,7 +501,7 @@
             <name>Use Cases</name>
             <t><xref target="DevID" /> discusses different environments, different settings, and the expectations of
             users and network operators.<xref target="scenario_table" />
-            ummarizes the expected degree of trust, network admin responsibility, complexity of supported network services 
+            summarizes the expected degree of trust, network admin responsibility, complexity of supported network services 
             and network support expectation from the user for the different use cases.</t>
 
             <table anchor="scenario_table" align="center">
@@ -602,8 +604,11 @@
          <?rfc include="reference.RFC.4861.xml" ?>        
          <?rfc include="reference.RFC.4862.xml" ?>
          <?rfc include="reference.RFC.4941.xml" ?>
+         <?rfc include="reference.RFC.6614.xml" ?>
          <?rfc include="reference.RFC.6620.xml" ?>
          <?rfc include="reference.RFC.7217.xml" ?>
+
+         <?rfc include="reference.I-D.ietf-radext-deprecating-radius.xml" ?>
 
 
 	   <reference anchor="IEEE_802" >
@@ -642,12 +647,20 @@
          <seriesInfo name="IEEE 802.11" value="" />
 	   </reference>
 
+      <reference anchor="IEEE_802.11bh" >
+         <front>
+            <title>IEEE 802.11bh-2024 - Wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) Specifications 
+               Amendment 1: Operation with Randomized and Changing MAC Addresses</title>
+            <author initials="" surname="" fullname="IEEE 802.11bh WG - 802 LAN/MAN Standards Committee"></author>
+            <date month="" year="2024"/>
+         </front>
+         <seriesInfo name="IEEE 802.11bh" value="" />
+	   </reference>   
+
       <reference anchor="IEEE_802.11i" >
          <front>
-            <title>IEEE 802.11i-2004 - IEEE Standard for information technology-Telecommunications and information exchange 
-               between systems-Local and metropolitan area networks-Specific requirements-Part 11: Wireless LAN Medium 
-               Access Control (MAC) and Physical Layer (PHY) specifications: Amendment 6: Medium Access Control (MAC) 
-               Security Enhancements</title>
+            <title>IEEE 802.11i-2004 - Wireless LAN Medium Access Control (MAC) and Physical Layer (PHY) specifications: 
+               Amendment 6: Medium Access Control (MAC) Security Enhancements</title>
             <author initials="" surname="" fullname="IEEE 802.11i WG - 802 LAN/MAN Standards Committee"></author>
             <date month="" year="2004"/>
          </front>
@@ -673,17 +686,18 @@
 	   <section numbered="true" toc="default">
 	   <name>802.1X with WPA2 / WPA3</name>
 	      
-	   <t>At the time of association to a Wi-Fi access point, 802.1X <xref target="IEEE 802.1X"/> authentication coupled 
+	   <t>At the time of association to a Wi-Fi access point, 802.1X <xref target="IEEE_802.1X"/> authentication coupled 
       with WPA2 or WPA3 <xref target="IEEE_802.11i"/>
       encryption schemes allows for the mutual identification of the client device or of the user of the device and an 
-      authentication authority. The authentication exchange is protected from eavesdropping. In this scenario, the 
+      authentication authority. Successful authentication will create a secure communication between the network and the 
+      user device. In this scenario, the 
       user or the device identity can be obfuscated from external observers. However, the authentication authority is in 
       most cases under the control of the same entity as the network access provider, thus making the user or device identity 
-      visible to the network owner. </t>
+      visible to the network owner.</t>
 	      
 	   <t>This scheme is therefore well-adapted to enterprise environments, where a level of trust is established between the user 
-      and the enterprise network operator. In this scheme, rotation of MAC address can occur through brief disconnections and 
-      reconnections (under the rules of 802.11-2020). Authentication may then need to reoccur, with an associated cost of service 
+      and the enterprise network operator. In this scheme, MAC address randomization can occur through brief disconnections and 
+      reconnections (under the rules of <xref target="IEEE_802.11bh"/>). Authentication may then need to reoccur, with an associated cost of service 
       disruption and additional load on the enterprise infrastructure, and an associated benefit of limiting the exposure of a 
       continuous MAC address to external observers. The adoption of this scheme is however limited outside of the enterprise 
       environment by the requirement to install an authentication profile on the end device, that would be recognized and accepted 
@@ -700,38 +714,48 @@
       <t> In order to alleviate some of the limitations listed above, the Wireless Broadband Alliance (WBA) OpenRoaming 
       Standard introduces an intermediate trusted relay between local venues and sources of identity  
       <xref target="draft-tomas-openroaming" />. The federation structure also extends the type of authorities that can be 
-      used as identity sources (compared to traditional enterprise-based 802.1X scheme for Wi-Fi), and also facilitates the 
-      establishment of trust between a local venue and an identity provider. Such procedure drammatically increases the likelihood 
-      that one or more identity profiles for the user or the device will be recognized by a local venue. At the same time, 
-      authentication does not occur to the local venue, thus offering the possibility for the user or the device to keep 
+      used as identity sources (compared to traditional enterprise-based 802.1X <xref target="IEEE_802.1X"/> scheme for Wi-Fi), and also facilitates the 
+      establishment of trust between a local network and an identity provider. Such procedure increases the likelihood 
+      that one or more identity profiles for the user or the device will be recognized by a local network. At the same time, 
+      authentication does not occur to the local network, thus offering the possibility for the user or the device to keep 
       their identity obfuscated from the local network operator, unless that operator specifically expresses the requirement to 
       disclose such identity (in which case the user has the option to accept or decline the connection and associated identity exposure).</t>
 
       <t>The OpenRoaming scheme therefore seems well-adapted to public Wi-Fi and hospitality environments, allowing for the 
       obfuscation of the identity from unauthorized entities, while also permitting mutual authentication between the device or the user 
-      and a trusted identity provider. Just like with standard 802.1X scheme for Wi-Fi, authentication allows the establishment of WPA2 
-      or WPA3 keys that can then be used to encrypt the communication between the device and the access point, thus obfuscating the traffic 
+      and a trusted identity provider. Just like with standard 802.1X <xref target="IEEE_802.1X"/> scheme for Wi-Fi, 
+      authentication allows the establishment of WPA2 or WPA3 keys <xref target="IEEE_802.11i"/> that can then 
+      be used to encrypt the communication between the device and the access point, thus obfuscating the traffic 
       from observers. </t>
 	
-      <t>Just like in the enterprise case, rotation of MAC address can occur through brief disconnections and reconnections 
-      (under the rules of 802.11-2020). Authentication may then need to reoccur, with an associated cost of service disruption and 
+      <t>Just like in the enterprise case, MAC address randomization can occur through brief disconnections and reconnections 
+      (under the rules of <xref target="IEEE_802.11bh"/>). Authentication may then need to reoccur, with an associated cost of service disruption and 
       additional load on the venue and identity provider infrastructure, and an associated benefit of limiting the exposure of a 
       continuous MAC address to external observers. Limitations of this scheme include the requirement to first install one or more profiles 
-      on the client device. This scheme also requires the local venue network to support RADSEC and the relay function, which may not be common 
-      in small hotspot networks and in home environments.</t>
+      on the client device. This scheme also requires the local network to support RADSEC <xref target="RFC6614"/>
+      and the relay function, which may not be common in small hotspot networks and in home environments.</t>
 
       <t>It is worth noting that, as part of collaborations between IETF MADINAS and WBA around OpenRoaming, some RADIUS privacy 
-      enhancements have been proposed in the IETF RADEXT group. For instance, [draft-ietf-radext-deprecating-radius] describes 
-      good practices in the use of Chargeable-User-Identity (CUI) between different visited networks, making it better suited for 
-      Public Wi-Fi and Hospitality use cases.</t>
+      enhancements have been proposed in the IETF RADEXT group. For instance, <xref target="I-D.ietf-radext-deprecating-radius"/>
+      describes good practices in the use of Chargeable-User-Identity (CUI) between different visited networks, making it better 
+      suited for Public Wi-Fi and Hospitality use cases.</t>
 
 	      
 	 </section>
 	
 	<section anchor="Proprietary" numbered="true" toc="default">
-	      <name>Proprietary RCM schemes</name>
-	<t> Most client device operating system vendors offer RCM schemes, enabled by default (or easy to enable) on client devices. With these schemes, the device changes its MAC address, when not associated, after having used a given MAC address for a semi-random duration window. These schemes also allow for the device to manifest a different MAC address in different SSIDs.</t>
-	<t> Such randomization scheme enables the device to limit the duration of exposure of a single MAC address to observers. In 802.11-2020, MAC address rotation is not allowed during a given association session, and thus rotation of MAC address can only occur through disconnection and reconnection. Authentication may then need to reoccur, with an associated cost of service disruption and additional load on the venue and identity provider infrastructure, directly proportional to the frequency of the rotation. The scheme is also not intended to protect from the exposure of other identifiers to the venue network (e.g., DHCP option 012 [host name] visible to the network between the AP and the DHCP server). </t>
+	   <name>Proprietary RCM schemes</name>
+	   <t> Most client device operating system vendors offer RCM schemes, enabled by default (or easy to enable) on client devices. 
+      With these schemes, the device changes its MAC address, when not associated, after having used a given MAC address for a 
+      semi-random duration window. These schemes also allow for the device to manifest a different MAC address in different SSIDs.</t>
+
+	   <t>Such randomization scheme enables the device to limit the duration of exposure of a single MAC address to observers. 
+         In <xref target="IEEE_802.11bh"/>, MAC address randomization is not allowed during a given association session, and thus MAC 
+         address randomization can only 
+         occur through disconnection and reconnection. Authentication may then need to reoccur, with an associated cost of service disruption and 
+         additional load on the venue and identity provider infrastructure, directly proportional to the frequency of the randomization. The scheme 
+         is also not intended to protect from the exposure of other identifiers to the venue network (e.g., DHCP option 012 [host name] visible to the 
+         network between the AP and the DHCPv4 server). </t>
 		
 	 </section>	
  </section>


### PR DESCRIPTION
# Unused references
 
[https://author-tools.ietf.org/api/idnits?url=https://www.ietf.org/archive/id/draft-ietf-madinas-use-cases-10.txt](https://urldefense.com/v3/__https:/author-tools.ietf.org/api/idnits?url=https:**Awww.ietf.org*archive*id*draft-ietf-madinas-use-cases-10.txt__;Ly8vLy8!!CQl3mcHX2A!B7D2g-dFMEF6p8A0bT68LU--rTi2RRh4O5PCQ83I-7QPA1VJsoXyhUNAq8FRf_PYK7afCtomM-pBFngh$) indicates that RFC 5176 and 8174 are not used, please remove from the reference list. The shepherd’s write-up also notices this issue.
 
# Title
 
What about “Randomized and Changing MAC Address: Context, Network Impact, and Use Cases” as the I-D is not mainly about use cases...
 
# Abstract
 
`MAC address rotation` seems to indicate a short cycle of MAC addresses, i.e., that the MAC address will be re-used within months or days. Suggest using ‘randomized’ like in the title.
 
Suggest splitting the abstract in two paragraphs: the context and the document purpose.
 
# Section 1
 
Wi-Fi initiated traffic can also be monitored outside of the air as most AP are connected over wired Ethernet, this should be mentioned.
 
s/multiple client and client OS vendors/multiple client*,* and client OS vendors/
 
in `given traffic flow` flow can be ambiguous as in the IETF context it is often linked to a 5-tuple TCP/UDP flow, suggest to use another term (even if I do not have any suggestion).
 
`There is a need to enumerate services` is probably too strong though, “It could be useful to ...” could be better.
 
Please explain the structure/flow of the document. The follow-up sections appear in random without a clear roadmap/flow of the I-D.
 
Some terms, e.g., ‘broadcast domain’, could be explained for non-familiar readers. Or making synonyms of “device = station = machine” in the document and “rotating = randomizing” ?
 
# Section 2
 
`Any device member of a network implementing IEEE 802 technologies includes several operating layers.` isn’t the layering not limited to IEEE networks ? The term MAC is more specific to IEEE 802 networks though, so suggest moving the IEEE qualification to the 2nd sentence.
 
` (and thus the target destination of the answer)` is probably useless
 
Please add a small figure for the bit allocation.
 
AFAIK, U/L bit has been renamed
 
If L=1,then *47* bits are locally administered for 48-bit addresses.
 
The 3rd paragraph could be rephrased as it looks weird after reading the 2nd one, e.g., let’s use the bit name rather than its position.
 
s/universal address/universally administrated address/ ?
 
Paragraph 5, let’s use bullets for the two types of devices.
 
Suggest having a sub-section for the last paragraph as it introduces the RCM.
 
AAA is authentication, authorization, accounting (and no need to expanse it multiple times)
 
State DHCPv4 rather than DHCP, as DHCPv6 behaves differently. Also add reference to DHCPv4 RFC
 
# Section 3.1
 
1st §: a lot of repetition with previous text.
 
Other §, please use bullet list for the entities else it is a little unclear.
 
2nd § unclear whether “IEEE 802 LAN” is for .11 or .3 or ?
 
s/OSI model layer 2/layer-2/
 
s/Layer-2/layer-2/ several places
 
Add a reference to 802.1X
 
In ` block the data portion` please specify what ‘data portion’ is
 
DHCPv6 is not about MAC addresses but DHCP Unique IT. This part *MUST* be rewritten and reference added.
 
# Section 3.2
 
Also use a bullet list format or sub-sub-section
 
Unsure whether WLAN operators and network access providers qualify as humans as opposed to organizations.
 
Tbh: I was unable to understand the definition of “network access providers”
 
# Section 5
 
s/ trains stations and airports/ trains stations, and airports/
 
s/L2/layer-2/
 
Expand BYOD
 
# Section 6
 
Think IPv6: ` basic address allocation service (DHCP)` is not correct for IPv6, it is about RA
 
s/ printing or local web service/ printing, or local web service/ check all “and” “or” for Oxford comma as it may change the semantics.
 
If QoE is not used elsewhere, then there is no point in defining the acronym.
 
# Section 6.1
 
Is there any data backing the statement made in §1 ? or add “as this section describes further down”
 
Should this be uppercase “I” in ` 802.11i Standard`+ add reference.
 
Assuming that “Other devices in the Layer 2 broadcast” are switches, please say so and then mention that unknown frames are flooded.
 
` data transmission` should probably be explained before (see above for a similar comment)
 
Again the lack of correct explanations about DHCPv6. The current *must* be made specific for DHCPv4 and text for DHCPv6 added.
 
About “Network devices using self-assigned IPv6 addresses” it is also applicable for static configuration of IP addresses (v4 and v6) and let’s be clear that the issue is not on these devices but on their peers.
 
“Routers keep track of which MAC address is on which interface” same as above, it is not a router problem or let’s be clear that the MAC address is one of peer.
 
# Section 6.2
 
Please use the same A, B, ... and names as in section 5.
 
# References
 
RFC 8174 is never used, please remove.
 
# Appendix A.1
 
Please add reference to WPA2 & WPS3
 
`The authentication exchange is protected from eavesdropping` why not saying “has a confidentiality service” or something similar or use the previous terminology of “observer”
 
` the user or the device identity can be obfuscated from external observers` in the text before ‘external’ was defined as after being routed, in this case, WPA is stopped anyway. So, I am unsure about the meaning of this sentence.
 
Should ` 802.11-2020`be updated to the 2024 version and a pointer to the reference section given ?
 
The 2022 number should be given with a reference.
 
# Appendix A.2
 
The term ‘venue’ is used for the first time and may not be clear.
 
` Just like in the enterprise case`if it refers to appendix A.1, then use the same term “WPA” and add a reference.
 
Add a reference to RADSEC.
 
Unsure whether the last § brings anything to a published RFC, you may want to keep it in the draft with a note to the RFC editor to remove it before publication.
 
# Appendix A.3
 
To be honest, I am not sure whether I understand the 1st §.
 
Same comment about IEEE 2020 version.
 
DHCP option 012 is *only* for IPv4. Please ensure to specify IPv4 and have text for IPv6.